### PR TITLE
Feat: 저장한 이벤트 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/otakumap/OtakumapApplication.java
+++ b/src/main/java/com/otakumap/OtakumapApplication.java
@@ -2,7 +2,9 @@ package com.otakumap;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OtakumapApplication {
 

--- a/src/main/java/com/otakumap/domain/event/entity/Event.java
+++ b/src/main/java/com/otakumap/domain/event/entity/Event.java
@@ -1,0 +1,57 @@
+package com.otakumap.domain.event.entity;
+
+import com.otakumap.domain.event.entity.enums.EventStatus;
+import com.otakumap.domain.event.entity.enums.EventType;
+import com.otakumap.domain.event.entity.enums.Genre;
+import com.otakumap.domain.event_like.entity.EventLike;
+import com.otakumap.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Event extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)")
+    private EventType type;
+
+    @Column(columnDefinition = "TEXT")
+    private String thumbnail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private Genre genre;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(15)", nullable = false)
+    private EventStatus status;
+
+    @Column(columnDefinition = "TEXT")
+    private String site;
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
+    private List<EventLike> eventLikeList = new ArrayList<>();
+}

--- a/src/main/java/com/otakumap/domain/event/entity/enums/EventStatus.java
+++ b/src/main/java/com/otakumap/domain/event/entity/enums/EventStatus.java
@@ -1,0 +1,6 @@
+package com.otakumap.domain.event.entity.enums;
+
+public enum EventStatus {
+    NOT_STARTED,
+    IN_PROCESS
+}

--- a/src/main/java/com/otakumap/domain/event/entity/enums/EventType.java
+++ b/src/main/java/com/otakumap/domain/event/entity/enums/EventType.java
@@ -1,0 +1,12 @@
+package com.otakumap.domain.event.entity.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum EventType {
+    POPUP_STORE("팝업 스토어"),
+    EXHIBITION("전시회"),
+    COLLABORATION_CAFE("콜라보 카페");
+
+    private final String description;
+}

--- a/src/main/java/com/otakumap/domain/event/entity/enums/Genre.java
+++ b/src/main/java/com/otakumap/domain/event/entity/enums/Genre.java
@@ -1,0 +1,14 @@
+package com.otakumap.domain.event.entity.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Genre {
+    SUNJEONG("순정"),
+    ACTION("액션"),
+    FANTASY("판타지"),
+    THRILLER("스릴러"),
+    SPORTS("스포츠");
+
+    private final String description;
+}

--- a/src/main/java/com/otakumap/domain/event/entity/enums/Genre.java
+++ b/src/main/java/com/otakumap/domain/event/entity/enums/Genre.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum Genre {
-    SUNJEONG("순정"),
+    ROMANCE("순정"),
     ACTION("액션"),
     FANTASY("판타지"),
     THRILLER("스릴러"),

--- a/src/main/java/com/otakumap/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/otakumap/domain/event/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.otakumap.domain.event.repository;
+
+import com.otakumap.domain.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
+++ b/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
@@ -1,0 +1,47 @@
+package com.otakumap.domain.event_like.controller;
+
+import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
+import com.otakumap.domain.event_like.service.EventLikeCommandService;
+import com.otakumap.domain.event_like.service.EventLikeQueryService;
+import com.otakumap.global.apiPayload.ApiResponse;
+import com.otakumap.global.validation.annotation.ExistEventLike;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Validated
+public class EventLikeController {
+    private final EventLikeQueryService eventLikeQueryService;
+    private final EventLikeCommandService eventLikeCommandService;
+
+    // 로그인 시 엔드포인트 변경 예정
+    @Operation(summary = "저장된 이벤트 목록 조회", description = "저장된 이벤트 목록을 불러옵니다.")
+    @GetMapping( "/users/{userId}/saved-events")
+    @Parameters({
+            @Parameter(name = "userId", description = "사용자 ID"),
+            @Parameter(name = "type", description = "이벤트 타입 -> 1: 팝업 스토어, 2: 전시회, 3: 콜라보 카페"),
+            @Parameter(name = "lastId", description = "마지막으로 조회된 저장된 이벤트 id, 처음 가져올 때 -> 0"),
+            @Parameter(name = "limit", description = "한 번에 조회할 최대 이벤트 수. 기본값은 10입니다.")
+    })
+    public ApiResponse<EventLikeResponseDTO.EventLikePreViewListDTO> getEventLikeList(@PathVariable Long userId, @RequestParam(required = false) Integer type, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
+        return ApiResponse.onSuccess(eventLikeQueryService.getEventLikeList(userId, type, lastId, limit));
+    }
+
+    @Operation(summary = "저장된 이벤트 삭제", description = "저장된 이벤트를 삭제합니다.")
+    @DeleteMapping("/saved-events")
+    @Parameters({
+            @Parameter(name = "eventIds", description = "저장된 이벤트 id List"),
+    })
+    public ApiResponse<String> deleteEventLike(@RequestParam(required = false) @ExistEventLike List<Long> eventIds) {
+        eventLikeCommandService.deleteEventLike(eventIds);
+        return ApiResponse.onSuccess("저장된 이벤트가 성공적으로 삭제되었습니다");
+    }
+}

--- a/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
@@ -1,0 +1,29 @@
+package com.otakumap.domain.event_like.converter;
+
+import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
+import com.otakumap.domain.event_like.entity.EventLike;
+
+import java.util.List;
+
+public class EventLikeConverter {
+    public static EventLikeResponseDTO.EventLikePreViewDTO eventLikePreViewDTO(EventLike eventLike) {
+        return EventLikeResponseDTO.EventLikePreViewDTO.builder()
+                .id(eventLike.getId())
+                .eventId(eventLike.getEvent().getId())
+                .name(eventLike.getEvent().getName())
+                .thumbnail(eventLike.getEvent().getThumbnail())
+                .startDate(eventLike.getEvent().getStartDate())
+                .endDate(eventLike.getEvent().getEndDate())
+                .isFavorite(eventLike.getIsFavorite())
+                .eventType(eventLike.getEvent().getType())
+                .build();
+
+    }
+    public static EventLikeResponseDTO.EventLikePreViewListDTO eventLikePreViewListDTO(List<EventLikeResponseDTO.EventLikePreViewDTO> eventLikes, boolean hasNext, Long lastId) {
+        return EventLikeResponseDTO.EventLikePreViewListDTO.builder()
+                .eventLikes(eventLikes)
+                .hasNext(hasNext)
+                .lastId(lastId)
+                .build();
+    }
+}

--- a/src/main/java/com/otakumap/domain/event_like/dto/EventLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/event_like/dto/EventLikeResponseDTO.java
@@ -1,0 +1,37 @@
+package com.otakumap.domain.event_like.dto;
+
+import com.otakumap.domain.event.entity.enums.EventType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class EventLikeResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EventLikePreViewDTO {
+        Long id;
+        Long eventId;
+        String name;
+        String thumbnail;
+        LocalDate startDate;
+        LocalDate endDate;
+        Boolean isFavorite;
+        EventType eventType;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EventLikePreViewListDTO {
+        List<EventLikeResponseDTO.EventLikePreViewDTO> eventLikes;
+        boolean hasNext;
+        Long lastId;
+    }
+}

--- a/src/main/java/com/otakumap/domain/event_like/entity/EventLike.java
+++ b/src/main/java/com/otakumap/domain/event_like/entity/EventLike.java
@@ -1,0 +1,35 @@
+package com.otakumap.domain.event_like.entity;
+
+import com.otakumap.domain.event.entity.Event;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class EventLike extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(name = "is_favorite", nullable = false)
+    @ColumnDefault("false")
+    private Boolean isFavorite;
+}

--- a/src/main/java/com/otakumap/domain/event_like/repository/EventLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/event_like/repository/EventLikeRepository.java
@@ -1,0 +1,17 @@
+package com.otakumap.domain.event_like.repository;
+
+import com.otakumap.domain.event.entity.enums.EventType;
+import com.otakumap.domain.event_like.entity.EventLike;
+import com.otakumap.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
+    Page<EventLike> findAllByUserIsOrderByCreatedAtDesc(User user, Pageable pageable);
+    Page<EventLike> findAllByUserIsAndCreatedAtLessThanOrderByCreatedAtDesc(User user, LocalDateTime createdAt, Pageable pageable);
+    Page<EventLike> findAllByUserIsAndEventTypeOrderByCreatedAtDesc(User user, EventType type, Pageable pageable);
+    Page<EventLike> findAllByUserIsAndEventTypeAndCreatedAtLessThanOrderByCreatedAtDesc(User user,  EventType type, LocalDateTime createdAt, Pageable pageable);
+}

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandService.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandService.java
@@ -1,0 +1,7 @@
+package com.otakumap.domain.event_like.service;
+
+import java.util.List;
+
+public interface EventLikeCommandService {
+    void deleteEventLike(List<Long> eventIds);
+}

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
@@ -1,0 +1,24 @@
+package com.otakumap.domain.event_like.service;
+
+import com.otakumap.domain.event_like.repository.EventLikeRepository;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EventLikeCommandServiceImpl implements EventLikeCommandService {
+    private final EventLikeRepository eventLikeRepository;
+    private final EntityManager entityManager;
+
+    @Override
+    public void deleteEventLike(List<Long> eventIds) {
+        eventLikeRepository.deleteAllByIdInBatch(eventIds);
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryService.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryService.java
@@ -1,0 +1,8 @@
+package com.otakumap.domain.event_like.service;
+
+import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
+
+public interface EventLikeQueryService {
+    EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(Long userId, Integer type, Long lastId, int limit);
+    boolean isEventLikeExist(Long id);
+}

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryServiceImpl.java
@@ -1,0 +1,69 @@
+package com.otakumap.domain.event_like.service;
+
+import com.otakumap.domain.event.entity.enums.EventType;
+import com.otakumap.domain.event_like.converter.EventLikeConverter;
+import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
+import com.otakumap.domain.event_like.entity.EventLike;
+import com.otakumap.domain.event_like.repository.EventLikeRepository;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.repository.UserRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.EventHandler;
+import com.otakumap.global.apiPayload.exception.handler.UserHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventLikeQueryServiceImpl implements EventLikeQueryService {
+    private final EventLikeRepository eventLikeRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(Long userId, Integer type, Long lastId, int limit) {
+        List<EventLike> result;
+        Pageable pageable = PageRequest.of(0, limit + 1);
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        EventType eventType = (type == null || type == 0) ? null : EventType.values()[type - 1];
+
+        if (lastId.equals(0L)) {
+            result = (eventType == null)
+                    ? eventLikeRepository.findAllByUserIsOrderByCreatedAtDesc(user, pageable).getContent()
+                    : eventLikeRepository.findAllByUserIsAndEventTypeOrderByCreatedAtDesc(user, eventType, pageable).getContent();
+        } else {
+            EventLike eventLike = eventLikeRepository.findById(lastId).orElseThrow(() -> new EventHandler(ErrorStatus.EVENT_LIKE_NOT_FOUND));
+            result =  (eventType == null)
+                    ? eventLikeRepository.findAllByUserIsAndCreatedAtLessThanOrderByCreatedAtDesc(user, eventLike.getCreatedAt(), pageable).getContent()
+                    : eventLikeRepository.findAllByUserIsAndEventTypeAndCreatedAtLessThanOrderByCreatedAtDesc(user, eventType, eventLike.getCreatedAt(), pageable).getContent();
+        }
+        return createEventLikePreviewListDTO(user, result, limit);
+    }
+
+
+    private EventLikeResponseDTO.EventLikePreViewListDTO createEventLikePreviewListDTO(User user, List<EventLike> eventLikes, int limit) {
+        boolean hasNext = eventLikes.size() > limit;
+        Long lastId = null;
+        if (hasNext) {
+            eventLikes = eventLikes.subList(0, eventLikes.size() - 1);
+            lastId = eventLikes.get(eventLikes.size() - 1).getId();
+        }
+        List<EventLikeResponseDTO.EventLikePreViewDTO> list = eventLikes
+                .stream()
+                .map(EventLikeConverter::eventLikePreViewDTO)
+                .collect(Collectors.toList());
+
+        return EventLikeConverter.eventLikePreViewListDTO(list, hasNext, lastId);
+    }
+
+    @Override
+    public boolean isEventLikeExist(Long id) {
+        return eventLikeRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -42,9 +42,6 @@ public class User extends BaseEntity {
     @Column(length = 15)
     private String nickname;
 
-    @Column(columnDefinition = "TEXT")
-    private String profileImage;
-
     @ColumnDefault("0")
     @Column(nullable = false)
     private Integer donation;

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -56,4 +56,8 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10) DEFAULT 'USER'", nullable = false)
     private Role role;
+
+    @ColumnDefault("FALSE")
+    @Column(name = "is_email_verified")
+    private Boolean isEmailVerified;
 }

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -1,0 +1,59 @@
+package com.otakumap.domain.user.entity;
+
+import com.otakumap.domain.user.entity.enums.Role;
+import com.otakumap.domain.user.entity.enums.SocialType;
+import com.otakumap.domain.user.entity.enums.UserStatus;
+import com.otakumap.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "user")
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20, nullable = false)
+    private String userId;
+
+    @Column(length = 20, nullable = false)
+    private String password;
+
+    @Column(length = 30, nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private SocialType socialType;
+
+    @Column(length = 15, nullable = false)
+    private String name;
+
+    @Column(length = 15)
+    private String nickname;
+
+    @Column(columnDefinition = "TEXT")
+    private String profileImage;
+
+    @ColumnDefault("0")
+    @Column(nullable = false)
+    private Integer donation;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10) DEFAULT 'ACTIVE'", nullable = false)
+    private UserStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10) DEFAULT 'USER'", nullable = false)
+    private Role role;
+}

--- a/src/main/java/com/otakumap/domain/user/entity/enums/Role.java
+++ b/src/main/java/com/otakumap/domain/user/entity/enums/Role.java
@@ -1,0 +1,6 @@
+package com.otakumap.domain.user.entity.enums;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/otakumap/domain/user/entity/enums/SocialType.java
+++ b/src/main/java/com/otakumap/domain/user/entity/enums/SocialType.java
@@ -1,0 +1,7 @@
+package com.otakumap.domain.user.entity.enums;
+
+public enum SocialType {
+    KAKAO,
+    GOOGLE,
+    NAVER
+}

--- a/src/main/java/com/otakumap/domain/user/entity/enums/UserStatus.java
+++ b/src/main/java/com/otakumap/domain/user/entity/enums/UserStatus.java
@@ -1,0 +1,6 @@
+package com.otakumap.domain.user.entity.enums;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.otakumap.domain.user.repository;
+
+import com.otakumap.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
@@ -16,8 +16,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    // 멤버 관려 에러
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다.");
+    // 멤버 관련 에러
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
+
+    // 이벤트 좋아요 관련 에러
+    EVENT_LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "EVENT4001", "저장되지 않은 이벤트입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/otakumap/global/apiPayload/exception/handler/EventHandler.java
+++ b/src/main/java/com/otakumap/global/apiPayload/exception/handler/EventHandler.java
@@ -1,0 +1,10 @@
+package com.otakumap.global.apiPayload.exception.handler;
+
+import com.otakumap.global.apiPayload.code.BaseErrorCode;
+import com.otakumap.global.apiPayload.exception.GeneralException;
+
+public class EventHandler extends GeneralException {
+  public EventHandler(BaseErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/otakumap/global/apiPayload/exception/handler/UserHandler.java
+++ b/src/main/java/com/otakumap/global/apiPayload/exception/handler/UserHandler.java
@@ -1,0 +1,10 @@
+package com.otakumap.global.apiPayload.exception.handler;
+
+import com.otakumap.global.apiPayload.code.BaseErrorCode;
+import com.otakumap.global.apiPayload.exception.GeneralException;
+
+public class UserHandler extends GeneralException {
+    public UserHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/otakumap/global/validation/annotation/ExistEventLike.java
+++ b/src/main/java/com/otakumap/global/validation/annotation/ExistEventLike.java
@@ -1,0 +1,17 @@
+package com.otakumap.global.validation.annotation;
+
+import com.otakumap.global.validation.validator.EventLikeExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = EventLikeExistValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistEventLike {
+    String message() default "유효하지 않은 이벤트 ID가 포함되어 있습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/otakumap/global/validation/validator/EventLikeExistValidator.java
+++ b/src/main/java/com/otakumap/global/validation/validator/EventLikeExistValidator.java
@@ -1,0 +1,38 @@
+package com.otakumap.global.validation.validator;
+
+import com.otakumap.domain.event_like.service.EventLikeQueryService;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.validation.annotation.ExistEventLike;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class EventLikeExistValidator implements ConstraintValidator<ExistEventLike, List<Long>> {
+    private final EventLikeQueryService eventLikeQueryService;
+
+    @Override
+    public void initialize(ExistEventLike constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<Long> eventIds, ConstraintValidatorContext context) {
+        if (eventIds == null || eventIds.isEmpty()) {
+            return false;
+        }
+
+        boolean isValid = eventIds.stream()
+                .allMatch(eventId -> eventLikeQueryService.isEventLikeExist(eventId));
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.EVENT_LIKE_NOT_FOUND.toString()).addConstraintViolation();
+        }
+        return isValid;
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #2 

## 📝 작업 내용
- 저장한 이벤트 목록 조회, 저장한 이벤트 삭제 API를 구현했습니다.
- 필요한 Event, EventLike, User 엔티티를 추가했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
