### PR TITLE
Feat: 일반 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 
   //
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// 이메일 인증 기능
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
 	// 이메일 인증 기능
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+---
+version: '3.8'
+services:
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"

--- a/src/main/java/com/otakumap/OtakumapApplication.java
+++ b/src/main/java/com/otakumap/OtakumapApplication.java
@@ -3,8 +3,10 @@ package com.otakumap;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableJpaAuditing
+@EnableAsync
 @SpringBootApplication
 public class OtakumapApplication {
 

--- a/src/main/java/com/otakumap/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/otakumap/domain/auth/controller/AuthController.java
@@ -2,17 +2,16 @@ package com.otakumap.domain.auth.controller;
 
 import com.otakumap.domain.auth.dto.AuthRequestDTO;
 import com.otakumap.domain.auth.dto.AuthResponseDTO;
+import com.otakumap.domain.auth.jwt.dto.JwtDTO;
 import com.otakumap.domain.auth.service.AuthCommandService;
 import com.otakumap.domain.user.converter.UserConverter;
 import com.otakumap.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -24,6 +23,12 @@ public class AuthController {
     @PostMapping("/signup")
     public ApiResponse<AuthResponseDTO.SignupResultDTO> signup(@RequestBody @Valid AuthRequestDTO.SignupDTO request) {
         return ApiResponse.onSuccess(UserConverter.toSignupResultDTO(authCommandService.signup(request)));
+    }
+
+    @Operation(summary = "일반 로그인", description = "일반 로그인 기능입니다.")
+    @PostMapping("/login")
+    public ApiResponse<AuthResponseDTO.LoginResultDTO> login(@RequestBody @Valid AuthRequestDTO.LoginDTO request) {
+        return ApiResponse.onSuccess(authCommandService.login(request));
     }
 
     @Operation(summary = "닉네임 중복 확인", description = "닉네임 중복 확인 기능입니다.")
@@ -48,5 +53,18 @@ public class AuthController {
     @PostMapping("/verify-code")
     public ApiResponse<AuthResponseDTO.VerifyCodeResultDTO> verifyEmail(@RequestBody @Valid AuthRequestDTO.VerifyCodeDTO request) {
         return ApiResponse.onSuccess(UserConverter.toVerifyCodeResultDTO(authCommandService.verifyCode(request)));
+    }
+
+    @Operation(summary = "토큰 재발급", description = "accessToken이 만료 시 refreshToken을 통해 accessToken을 재발급합니다.")
+    @PostMapping("/reissue")
+    public ApiResponse<JwtDTO> reissueToken(@RequestHeader("RefreshToken") String refreshToken) {
+        return ApiResponse.onSuccess(authCommandService.reissueToken(refreshToken));
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃 기능입니다.")
+    @PostMapping("/logout")
+    public ApiResponse<String> logout(HttpServletRequest request) {
+        authCommandService.logout(request);
+        return ApiResponse.onSuccess("로그아웃 되었습니다.");
     }
 }

--- a/src/main/java/com/otakumap/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/otakumap/domain/auth/controller/AuthController.java
@@ -46,7 +46,8 @@ public class AuthController {
     @Operation(summary = "이메일 인증 메일 전송", description = "이메일 인증을 위한 메일 전송 기능입니다.")
     @PostMapping("/verify-email")
     public ApiResponse<String> verifyEmail(@RequestBody @Valid AuthRequestDTO.VerifyEmailDTO request) throws MessagingException {
-        return ApiResponse.onSuccess(authCommandService.verifyEmail(request));
+        authCommandService.verifyEmail(request);
+        return ApiResponse.onSuccess("이메일 인증이 성공적으로 완료되었습니다.");
     }
 
     @Operation(summary = "이메일 코드 인증", description = "이메일 코드 인증 기능입니다.")

--- a/src/main/java/com/otakumap/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/otakumap/domain/auth/controller/AuthController.java
@@ -1,0 +1,52 @@
+package com.otakumap.domain.auth.controller;
+
+import com.otakumap.domain.auth.dto.AuthRequestDTO;
+import com.otakumap.domain.auth.dto.AuthResponseDTO;
+import com.otakumap.domain.auth.service.AuthCommandService;
+import com.otakumap.domain.user.converter.UserConverter;
+import com.otakumap.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.mail.MessagingException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthCommandService authCommandService;
+
+    @Operation(summary = "회원가입", description = "회원가입 기능입니다.")
+    @PostMapping("/signup")
+    public ApiResponse<AuthResponseDTO.SignupResultDTO> signup(@RequestBody @Valid AuthRequestDTO.SignupDTO request) {
+        return ApiResponse.onSuccess(UserConverter.toSignupResultDTO(authCommandService.signup(request)));
+    }
+
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임 중복 확인 기능입니다.")
+    @PostMapping("/check-nickname")
+    public ApiResponse<AuthResponseDTO.CheckNicknameResultDTO> checkNickname(@RequestBody @Valid AuthRequestDTO.CheckNicknameDTO request) {
+        return ApiResponse.onSuccess(UserConverter.toCheckNicknameResultDTO(authCommandService.checkNickname(request)));
+    }
+
+    @Operation(summary = "아이디 중복 확인", description = "아이디 중복 확인 기능입니다.")
+    @PostMapping("/check-id")
+    public ApiResponse<AuthResponseDTO.CheckIdResultDTO> checkId(@RequestBody @Valid AuthRequestDTO.CheckIdDTO request) {
+        return ApiResponse.onSuccess(UserConverter.toCheckIdResultDTO(authCommandService.checkId(request)));
+    }
+
+    @Operation(summary = "이메일 인증 메일 전송", description = "이메일 인증을 위한 메일 전송 기능입니다.")
+    @PostMapping("/verify-email")
+    public ApiResponse<String> verifyEmail(@RequestBody @Valid AuthRequestDTO.VerifyEmailDTO request) throws MessagingException {
+        return ApiResponse.onSuccess(authCommandService.verifyEmail(request));
+    }
+
+    @Operation(summary = "이메일 코드 인증", description = "이메일 코드 인증 기능입니다.")
+    @PostMapping("/verify-code")
+    public ApiResponse<AuthResponseDTO.VerifyCodeResultDTO> verifyEmail(@RequestBody @Valid AuthRequestDTO.VerifyCodeDTO request) {
+        return ApiResponse.onSuccess(UserConverter.toVerifyCodeResultDTO(authCommandService.verifyCode(request)));
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/AuthRequestDTO.java
@@ -1,0 +1,65 @@
+package com.otakumap.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+public class AuthRequestDTO {
+    @Getter
+    public static class SignupDTO {
+        @NotBlank(message = "이름 입력은 필수입니다.")
+        @Schema(description = "name", example = "오타쿠맵")
+        String name;
+
+        @NotBlank(message = "닉네임 입력은 필수입니다.")
+        @Schema(description = "nickname", example = "오타쿠")
+        String nickname;
+
+        @NotBlank(message = "아이디 입력은 필수입니다.")
+        @Schema(description = "userId", example = "otakumap1234")
+        String userId;
+
+        @NotBlank(message = "이메일 입력은 필수입니다.")
+        @Schema(description = "email", example = "otakumap1234@gmail.com")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")
+        String email;
+
+        @NotBlank(message = "비밀번호 입력은 필수입니다.")
+        @Schema(description = "password", example = "otakumap1234!")
+        @Pattern(regexp = "^(?:(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,})|(?:(?=.*[a-zA-Z])(?=.*\\d).{10,})|(?:(?=.*[a-zA-Z])(?=.*[!@#$%^&*]).{10,})|(?:(?=.*\\d)(?=.*[!@#$%^&*]).{10,})$",
+                message = "영문, 숫자, 특수문자 중 2종류 이상을 조합하여 최소 10자리 이상이거나, 영문, 숫자, 특수문자 모두를 포함하여 최소 8자리 이상 입력해야 합니다.")
+        String password;
+
+        @NotBlank(message = "비밀번호 재확인 입력은 필수 입니다.")
+        @Schema(description = "passwordCheck", example = "otakumap1234!")
+        String passwordCheck;
+    }
+
+    @Getter
+    public static class CheckNicknameDTO {
+        @NotNull
+        String nickname;
+    }
+
+    @Getter
+    public static class CheckIdDTO {
+        @NotNull
+        String userId;
+    }
+
+    @Getter
+    public static class VerifyEmailDTO {
+        @NotNull
+        String email;
+    }
+
+    @Getter
+    public static class VerifyCodeDTO {
+        @NotNull
+        String code;
+        @NotNull
+        String email;
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/AuthRequestDTO.java
@@ -38,6 +38,14 @@ public class AuthRequestDTO {
     }
 
     @Getter
+    public static class LoginDTO {
+        @NotNull
+        String userId;
+        @NotNull
+        String password;
+    }
+
+    @Getter
     public static class CheckNicknameDTO {
         @NotNull
         String nickname;

--- a/src/main/java/com/otakumap/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/AuthResponseDTO.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 public class AuthResponseDTO {
-
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
@@ -17,6 +16,17 @@ public class AuthResponseDTO {
         Long id;
         LocalDateTime createdAt;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class LoginResultDTO {
+        Long id;
+        String accessToken;
+        String refreshToken;
+    }
+
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/com/otakumap/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/AuthResponseDTO.java
@@ -1,0 +1,44 @@
+package com.otakumap.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class AuthResponseDTO {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class SignupResultDTO {
+        Long id;
+        LocalDateTime createdAt;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class CheckNicknameResultDTO {
+        boolean isDuplicated;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class CheckIdResultDTO {
+        boolean isDuplicated;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class VerifyCodeResultDTO {
+        boolean isVerified;
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/annotation/CurrentUser.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.otakumap.domain.auth.jwt.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface CurrentUser {
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/dto/JwtDTO.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/dto/JwtDTO.java
@@ -1,0 +1,11 @@
+package com.otakumap.domain.auth.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtDTO {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/filter/JwtFilter.java
@@ -40,14 +40,13 @@ public class JwtFilter extends OncePerRequestFilter {
                 if (blackListValue != null && blackListValue.equals("logout")) {
                     throw new AuthHandler(ErrorStatus.TOKEN_LOGGED_OUT);
                 }
-                String userId = jwtProvider.getUserId(accessToken);
 
+                String email = jwtProvider.getEmail(accessToken);
                 //유저와 토큰 일치 시 userDetails 생성
-                UserDetails userDetails = principalDetailsService.loadUserByUsername(userId);
+                UserDetails userDetails = principalDetailsService.loadUserByUsername(email);
                 if (userDetails != null) {
                     //userDetails, password, role -> 접근 권한 인증 Token 생성
                     Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
-
                     //현재 Request의 Security Context에 접근 권한 설정
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } else {

--- a/src/main/java/com/otakumap/domain/auth/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/filter/JwtFilter.java
@@ -1,0 +1,73 @@
+package com.otakumap.domain.auth.jwt.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.otakumap.domain.auth.jwt.userdetails.PrincipalDetailsService;
+import com.otakumap.domain.auth.jwt.util.JwtProvider;
+import com.otakumap.global.apiPayload.ApiResponse;
+import com.otakumap.global.apiPayload.code.BaseErrorCode;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.GeneralException;
+import com.otakumap.global.apiPayload.exception.handler.AuthHandler;
+import com.otakumap.global.util.RedisUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+    private final RedisUtil redisUtil;
+    private final PrincipalDetailsService principalDetailsService;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String accessToken =  jwtProvider.resolveAccessToken(request);
+
+            //JWT 유효성 검증
+            if(accessToken != null && jwtProvider.validateToken(accessToken)) {
+                String blackListValue = (String) redisUtil.get(accessToken);
+                if (blackListValue != null && blackListValue.equals("logout")) {
+                    throw new AuthHandler(ErrorStatus.TOKEN_LOGGED_OUT);
+                }
+                String userId = jwtProvider.getUserId(accessToken);
+
+                //유저와 토큰 일치 시 userDetails 생성
+                UserDetails userDetails = principalDetailsService.loadUserByUsername(userId);
+                if (userDetails != null) {
+                    //userDetails, password, role -> 접근 권한 인증 Token 생성
+                    Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+
+                    //현재 Request의 Security Context에 접근 권한 설정
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } else {
+                    throw new AuthHandler(ErrorStatus.USER_NOT_FOUND);
+                }
+            }
+            // 다음 필터로 넘기기
+            filterChain.doFilter(request, response);
+        } catch (GeneralException e) {
+            BaseErrorCode code = e.getCode();
+            response.setContentType("application/json; charset=UTF-8");
+            response.setStatus(code.getReasonHttpStatus().getHttpStatus().value());
+
+            ApiResponse<Object> errorResponse = ApiResponse.onFailure(
+                    code.getReasonHttpStatus().getCode(),
+                    code.getReasonHttpStatus().getMessage(),
+                    e.getMessage());
+
+            ObjectMapper om = new ObjectMapper();
+            om.writeValue(response.getOutputStream(), errorResponse);
+        }
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.otakumap.domain.auth.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.otakumap.global.apiPayload.ApiResponse;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j(topic = "FORBIDDEN_EXCEPTION_HANDLER")
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        log.warn("Access Denied: ", accessDeniedException);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        ApiResponse<Object> errorResponse = ApiResponse.onFailure(
+                ErrorStatus._FORBIDDEN.getReasonHttpStatus().getCode(),
+                ErrorStatus._FORBIDDEN.getReasonHttpStatus().getMessage(),
+                accessDeniedException.getMessage()
+        );
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.otakumap.domain.auth.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.otakumap.global.apiPayload.ApiResponse;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j(topic = "UNAUTHORIZATION_EXCEPTION_HANDLER")
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        log.error("No Authorities", authException);
+
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        ApiResponse<Object> errorResponse = ApiResponse.onFailure(
+                ErrorStatus._UNAUTHORIZED.getReasonHttpStatus().getCode(),
+                ErrorStatus._UNAUTHORIZED.getReasonHttpStatus().getMessage(),
+                authException.getMessage()
+        );
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/resolver/AuthenticatedUserResolver.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/resolver/AuthenticatedUserResolver.java
@@ -1,0 +1,39 @@
+package com.otakumap.domain.auth.jwt.resolver;
+
+import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
+import com.otakumap.domain.auth.jwt.userdetails.PrincipalDetails;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthenticatedUserResolver implements HandlerMethodArgumentResolver {
+    private final UserQueryService userQueryService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class) && parameter.getParameterType().isAssignableFrom(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null) {
+            PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+            return userQueryService.getUserByUserId(principalDetails.getUsername());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/resolver/CurrentUserResolver.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/resolver/CurrentUserResolver.java
@@ -18,7 +18,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class AuthenticatedUserResolver implements HandlerMethodArgumentResolver {
+public class CurrentUserResolver implements HandlerMethodArgumentResolver {
     private final UserQueryService userQueryService;
 
     @Override
@@ -32,7 +32,7 @@ public class AuthenticatedUserResolver implements HandlerMethodArgumentResolver 
 
         if (authentication != null) {
             PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
-            return userQueryService.getUserByUserId(principalDetails.getUsername());
+            return userQueryService.getUserByEmail(principalDetails.getUsername());
         }
         return null;
     }

--- a/src/main/java/com/otakumap/domain/auth/jwt/userdetails/PrincipalDetails.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/userdetails/PrincipalDetails.java
@@ -1,0 +1,57 @@
+package com.otakumap.domain.auth.jwt.userdetails;
+
+import com.otakumap.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class PrincipalDetails implements UserDetails {
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add(user.getRole().toString());
+
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserId();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/userdetails/PrincipalDetails.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/userdetails/PrincipalDetails.java
@@ -27,7 +27,7 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getUserId();
+        return user.getEmail();
     }
 
     @Override

--- a/src/main/java/com/otakumap/domain/auth/jwt/userdetails/PrincipalDetailsService.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/userdetails/PrincipalDetailsService.java
@@ -16,8 +16,8 @@ public class PrincipalDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
-        User user = userRepository.findByUserId(userId).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
         return new PrincipalDetails(user);
     }
 }

--- a/src/main/java/com/otakumap/domain/auth/jwt/userdetails/PrincipalDetailsService.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/userdetails/PrincipalDetailsService.java
@@ -1,0 +1,23 @@
+package com.otakumap.domain.auth.jwt.userdetails;
+
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.repository.UserRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.AuthHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User user = userRepository.findByUserId(userId).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
+        return new PrincipalDetails(user);
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/jwt/util/JwtProvider.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/util/JwtProvider.java
@@ -1,0 +1,142 @@
+package com.otakumap.domain.auth.jwt.util;
+
+import com.otakumap.domain.auth.jwt.dto.JwtDTO;
+import com.otakumap.domain.auth.jwt.userdetails.PrincipalDetails;
+import com.otakumap.domain.auth.jwt.userdetails.PrincipalDetailsService;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.AuthHandler;
+import com.otakumap.global.util.RedisUtil;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+public class JwtProvider {
+    private final PrincipalDetailsService userDetailsService;
+    private final SecretKey secret;
+    private final Long accessExpiration;
+    private final Long refreshExpiration;
+    private final RedisUtil redisUtil;
+
+    public JwtProvider(
+            PrincipalDetailsService userDetailsService,
+            @Value("${spring.jwt.secret}") String secret,
+            @Value("${spring.jwt.token.access-expiration-time}") Long accessExpiration,
+            @Value("${spring.jwt.token.refresh-expiration-time}") Long refreshExpiration,
+            RedisUtil redisUtil) {
+        this.userDetailsService = userDetailsService;
+        this.secret = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessExpiration = accessExpiration;
+        this.refreshExpiration = refreshExpiration;
+        this.redisUtil = redisUtil;
+    }
+
+    // AccessToken 생성
+    public String createAccessToken(PrincipalDetails userDetails) {
+        Instant issuedAt = Instant.now();
+        Instant expiredAt = issuedAt.plusMillis(accessExpiration);
+
+        return Jwts.builder()
+                .setHeader(Map.of("alg", "HS256", "typ", "JWT"))
+                .setSubject(userDetails.getUsername())
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiredAt))
+                .signWith(secret, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // RefreshToken 생성
+    public String createRefreshToken(PrincipalDetails userDetails) {
+        Instant issuedAt = Instant.now();
+        Instant expiredAt = issuedAt.plusMillis(refreshExpiration);
+
+        String refreshToken = Jwts.builder()
+                .setHeader(Map.of("alg", "HS256", "typ", "JWT"))
+                .setSubject(userDetails.getUsername())
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiredAt))
+                .signWith(secret, SignatureAlgorithm.HS256)
+                .compact();
+        redisUtil.set(userDetails.getUsername(), refreshToken);
+        redisUtil.expire(userDetails.getUsername(), refreshExpiration, TimeUnit.MILLISECONDS);
+        return refreshToken;
+    }
+
+    // 헤더에서 토큰 추출
+    public String resolveAccessToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            return null;
+        }
+        return header.split(" ")[1];
+    }
+
+    // AccessToken 유효성 확인
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claims = getClaims(token);
+            return claims.getBody().getExpiration().after(Date.from(Instant.now()));
+        } catch (JwtException e) {
+            log.error(e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.error(e.getMessage() + ": 토큰이 유효하지 않습니다.");
+            return false;
+        }
+    }
+
+    // RefreshToken 유효성 확인
+    public void validateRefreshToken(String refreshToken) {
+        String username = getUserId(refreshToken);
+
+        //redis 확인
+        if (!redisUtil.exists(username)) {
+            throw new AuthHandler(ErrorStatus.INVALID_TOKEN);
+        }
+    }
+
+    //userId 추출
+    public String getUserId(String token) {
+        return getClaims(token).getBody().getSubject();
+    }
+
+    //토큰의 클레임 가져오는 메서드
+    public Jws<Claims> getClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(secret)
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (Exception e) {
+            throw new AuthHandler(ErrorStatus.INVALID_TOKEN);
+        }
+    }
+
+    // 토큰 재발급
+    public JwtDTO reissueToken(String refreshToken) throws SignatureException {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(getUserId(refreshToken));
+
+        return new JwtDTO(
+                createAccessToken((PrincipalDetails) userDetails),
+                createRefreshToken((PrincipalDetails)userDetails)
+        );
+    }
+
+    // 토큰 유효시간 반환
+    public Long getExpTime(String token) {
+        return getClaims(token).getPayload().getExpiration().getTime();
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/otakumap/domain/auth/service/AuthCommandService.java
@@ -1,0 +1,13 @@
+package com.otakumap.domain.auth.service;
+
+import com.otakumap.domain.auth.dto.AuthRequestDTO;
+import com.otakumap.domain.user.entity.User;
+import jakarta.mail.MessagingException;
+
+public interface AuthCommandService {
+    User signup(AuthRequestDTO.SignupDTO request);
+    boolean checkNickname(AuthRequestDTO.CheckNicknameDTO request);
+    boolean checkId(AuthRequestDTO.CheckIdDTO request);
+    String verifyEmail(AuthRequestDTO.VerifyEmailDTO request) throws MessagingException;
+    boolean verifyCode(AuthRequestDTO.VerifyCodeDTO request);
+}

--- a/src/main/java/com/otakumap/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/otakumap/domain/auth/service/AuthCommandService.java
@@ -12,7 +12,7 @@ public interface AuthCommandService {
     AuthResponseDTO.LoginResultDTO login(AuthRequestDTO.LoginDTO request);
     boolean checkNickname(AuthRequestDTO.CheckNicknameDTO request);
     boolean checkId(AuthRequestDTO.CheckIdDTO request);
-    String verifyEmail(AuthRequestDTO.VerifyEmailDTO request) throws MessagingException;
+    void verifyEmail(AuthRequestDTO.VerifyEmailDTO request) throws MessagingException;
     boolean verifyCode(AuthRequestDTO.VerifyCodeDTO request);
     JwtDTO reissueToken(String refreshToken);
     void logout(HttpServletRequest request);

--- a/src/main/java/com/otakumap/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/otakumap/domain/auth/service/AuthCommandService.java
@@ -1,13 +1,19 @@
 package com.otakumap.domain.auth.service;
 
 import com.otakumap.domain.auth.dto.AuthRequestDTO;
+import com.otakumap.domain.auth.dto.AuthResponseDTO;
+import com.otakumap.domain.auth.jwt.dto.JwtDTO;
 import com.otakumap.domain.user.entity.User;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface AuthCommandService {
     User signup(AuthRequestDTO.SignupDTO request);
+    AuthResponseDTO.LoginResultDTO login(AuthRequestDTO.LoginDTO request);
     boolean checkNickname(AuthRequestDTO.CheckNicknameDTO request);
     boolean checkId(AuthRequestDTO.CheckIdDTO request);
     String verifyEmail(AuthRequestDTO.VerifyEmailDTO request) throws MessagingException;
     boolean verifyCode(AuthRequestDTO.VerifyCodeDTO request);
+    JwtDTO reissueToken(String refreshToken);
+    void logout(HttpServletRequest request);
 }

--- a/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
@@ -51,8 +51,8 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         PrincipalDetails memberDetails = new PrincipalDetails(user);
 
         // 로그인 성공 시 토큰 생성
-        String accessToken = jwtProvider.createAccessToken(memberDetails);
-        String refreshToken = jwtProvider.createRefreshToken(memberDetails);
+        String accessToken = jwtProvider.createAccessToken(memberDetails, user.getId());
+        String refreshToken = jwtProvider.createRefreshToken(memberDetails, user.getId());
 
         return UserConverter.toLoginResultDTO(user, accessToken, refreshToken);
     }
@@ -111,7 +111,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             redisUtil.set(accessToken, "logout");
             redisUtil.expire(accessToken, jwtProvider.getExpTime(accessToken), TimeUnit.MILLISECONDS);
             // RefreshToken 삭제
-            redisUtil.delete(jwtProvider.getUserId(accessToken));
+            redisUtil.delete(jwtProvider.getEmail(accessToken));
         } catch (ExpiredJwtException e) {
             throw new AuthHandler(ErrorStatus.TOKEN_EXPIRED);
         }

--- a/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
@@ -10,12 +10,14 @@ import com.otakumap.global.util.RedisUtil;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthCommandServiceImpl implements AuthCommandService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
     private final MailService mailService;
 
@@ -24,9 +26,9 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         if(!request.getPassword().equals(request.getPasswordCheck())) {
             throw new AuthHandler(ErrorStatus.PASSWORD_NOT_EQUAL);
         }
-
-        User user = UserConverter.toUser(request);
-        return userRepository.save(user);
+        User newUser = UserConverter.toUser(request);
+        newUser.encodePassword(passwordEncoder.encode(request.getPassword()));
+        return userRepository.save(newUser);
     }
 
     @Override

--- a/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
@@ -1,17 +1,25 @@
 package com.otakumap.domain.auth.service;
 
 import com.otakumap.domain.auth.dto.AuthRequestDTO;
+import com.otakumap.domain.auth.dto.AuthResponseDTO;
+import com.otakumap.domain.auth.jwt.dto.JwtDTO;
+import com.otakumap.domain.auth.jwt.userdetails.PrincipalDetails;
+import com.otakumap.domain.auth.jwt.util.JwtProvider;
 import com.otakumap.domain.user.converter.UserConverter;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.domain.user.repository.UserRepository;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
 import com.otakumap.global.apiPayload.exception.handler.AuthHandler;
 import com.otakumap.global.util.RedisUtil;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +28,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
     private final MailService mailService;
+    private final JwtProvider jwtProvider;
 
     @Override
     public User signup(AuthRequestDTO.SignupDTO request) {
@@ -32,8 +41,24 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     }
 
     @Override
+    public AuthResponseDTO.LoginResultDTO login(AuthRequestDTO.LoginDTO request) {
+        User user = userRepository.findByUserId(request.getUserId()).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
+
+        if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new AuthHandler(ErrorStatus.PASSWORD_NOT_EQUAL);
+        }
+
+        PrincipalDetails memberDetails = new PrincipalDetails(user);
+
+        // 로그인 성공 시 토큰 생성
+        String accessToken = jwtProvider.createAccessToken(memberDetails);
+        String refreshToken = jwtProvider.createRefreshToken(memberDetails);
+
+        return UserConverter.toLoginResultDTO(user, accessToken, refreshToken);
+    }
+
+    @Override
     public boolean checkNickname(AuthRequestDTO.CheckNicknameDTO request) {
-        System.out.println(request.getNickname());
         return userRepository.existsByNickname(request.getNickname());
     }
 
@@ -54,7 +79,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     @Override
     public boolean verifyCode(AuthRequestDTO.VerifyCodeDTO request) {
-        String authCode = redisUtil.getData(request.getEmail());
+        String authCode = (String) redisUtil.get(request.getEmail());
         if (authCode == null) {
             throw new AuthHandler(ErrorStatus.EMAIL_CODE_EXPIRED);
         }
@@ -62,5 +87,31 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             throw new AuthHandler(ErrorStatus.CODE_NOT_EQUAL);
         }
         return true;
+    }
+
+    @Override
+    public JwtDTO reissueToken(String refreshToken) {
+        try {
+            jwtProvider.validateRefreshToken(refreshToken);
+            return jwtProvider.reissueToken(refreshToken);
+        } catch (ExpiredJwtException eje) {
+            throw new AuthHandler(ErrorStatus.TOKEN_EXPIRED);
+        } catch (IllegalArgumentException iae) {
+            throw new AuthHandler(ErrorStatus.INVALID_TOKEN);
+        }
+    }
+
+    @Override
+    public void logout(HttpServletRequest request) {
+        try {
+            String accessToken = jwtProvider.resolveAccessToken(request);
+            // 블랙리스트에 저장
+            redisUtil.set(accessToken, "logout");
+            redisUtil.expire(accessToken, jwtProvider.getExpTime(accessToken), TimeUnit.MILLISECONDS);
+            // RefreshToken 삭제
+            redisUtil.delete(jwtProvider.getUserId(accessToken));
+        } catch (ExpiredJwtException e) {
+            throw new AuthHandler(ErrorStatus.TOKEN_EXPIRED);
+        }
     }
 }

--- a/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
@@ -68,13 +68,15 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     }
 
     @Override
-    public String verifyEmail(AuthRequestDTO.VerifyEmailDTO request) throws MessagingException {
+    public void verifyEmail(AuthRequestDTO.VerifyEmailDTO request) throws MessagingException {
         try {
+            if(userRepository.existsByEmail(request.getEmail())) {
+                throw new AuthHandler(ErrorStatus.EMAIL_ALREADY_EXISTS);
+            }
             mailService.sendEmail(request.getEmail());
         } catch (MailException e) {
             throw new AuthHandler(ErrorStatus.EMAIL_SEND_FAILED);
         }
-        return "이메일 인증이 성공적으로 완료되었습니다.";
     }
 
     @Override

--- a/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/auth/service/AuthCommandServiceImpl.java
@@ -1,0 +1,64 @@
+package com.otakumap.domain.auth.service;
+
+import com.otakumap.domain.auth.dto.AuthRequestDTO;
+import com.otakumap.domain.user.converter.UserConverter;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.repository.UserRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.AuthHandler;
+import com.otakumap.global.util.RedisUtil;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.MailException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCommandServiceImpl implements AuthCommandService {
+    private final UserRepository userRepository;
+    private final RedisUtil redisUtil;
+    private final MailService mailService;
+
+    @Override
+    public User signup(AuthRequestDTO.SignupDTO request) {
+        if(!request.getPassword().equals(request.getPasswordCheck())) {
+            throw new AuthHandler(ErrorStatus.PASSWORD_NOT_EQUAL);
+        }
+
+        User user = UserConverter.toUser(request);
+        return userRepository.save(user);
+    }
+
+    @Override
+    public boolean checkNickname(AuthRequestDTO.CheckNicknameDTO request) {
+        System.out.println(request.getNickname());
+        return userRepository.existsByNickname(request.getNickname());
+    }
+
+    @Override
+    public boolean checkId(AuthRequestDTO.CheckIdDTO request) {
+        return userRepository.existsByUserId(request.getUserId());
+    }
+
+    @Override
+    public String verifyEmail(AuthRequestDTO.VerifyEmailDTO request) throws MessagingException {
+        try {
+            mailService.sendEmail(request.getEmail());
+        } catch (MailException e) {
+            throw new AuthHandler(ErrorStatus.EMAIL_SEND_FAILED);
+        }
+        return "이메일 인증이 성공적으로 완료되었습니다.";
+    }
+
+    @Override
+    public boolean verifyCode(AuthRequestDTO.VerifyCodeDTO request) {
+        String authCode = redisUtil.getData(request.getEmail());
+        if (authCode == null) {
+            throw new AuthHandler(ErrorStatus.EMAIL_CODE_EXPIRED);
+        }
+        if (!authCode.equals(request.getCode())) {
+            throw new AuthHandler(ErrorStatus.CODE_NOT_EQUAL);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/service/MailService.java
+++ b/src/main/java/com/otakumap/domain/auth/service/MailService.java
@@ -1,0 +1,75 @@
+package com.otakumap.domain.auth.service;
+
+import com.otakumap.global.util.RedisUtil;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    private final JavaMailSender javaMailSender;
+
+    private final RedisUtil redisUtil;
+
+    @Value("${spring.mail.username}")
+    private String senderEmail;
+
+    // 인증 코드 생성
+    private String createCode() {
+        int leftLimit = 48; // number '0'
+        int rightLimit = 122; // alphabet 'z'
+        int targetStringLength = 6;
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 | i >= 97))
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+
+    // 이메일 폼 생성
+    private MimeMessage createEmailForm(String email, String code) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.setFrom(senderEmail);
+        message.addRecipients(MimeMessage.RecipientType.TO, email);
+
+        message.setSubject("오타쿠맵 이메일 인증 안내");
+        String body = "";
+        body += "<p>회원가입을 위한 이메일 인증을 진행합니다.</p>";
+        body += "<p>아래 발급된 인증번호를 입력하여 인증을 완료해주세요.</p>";
+        body += "<br>";
+        body += "<p>인증번호 " + code + "</p>";
+        message.setText(body, "UTF-8", "html");
+
+        // Redis 에 해당 인증코드 인증 시간 설정(30분)
+        redisUtil.setDataExpire(email, code, 60 * 30L);
+
+        return message;
+    }
+
+    // 메일 발송
+    @Async
+    public void sendEmail(String sendEmail) throws MessagingException {
+        if (redisUtil.existData(sendEmail)) {
+            redisUtil.deleteData(sendEmail);
+        }
+        String authCode = createCode();
+        MimeMessage message = createEmailForm(sendEmail, authCode); // 메일 생성
+        try {
+            javaMailSender.send(message); // 메일 발송
+        } catch (MailException e) {
+            throw new MailSendException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
@@ -1,0 +1,48 @@
+package com.otakumap.domain.user.converter;
+
+import com.otakumap.domain.auth.dto.AuthRequestDTO;
+import com.otakumap.domain.auth.dto.AuthResponseDTO;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.entity.enums.Role;
+import com.otakumap.domain.user.entity.enums.UserStatus;
+
+import java.time.LocalDateTime;
+
+public class UserConverter {
+    public static User toUser(AuthRequestDTO.SignupDTO request) {
+        return User.builder()
+                .name(request.getName())
+                .nickname(request.getNickname())
+                .userId(request.getUserId())
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .role(Role.USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    public static AuthResponseDTO.SignupResultDTO toSignupResultDTO(User user) {
+        return AuthResponseDTO.SignupResultDTO.builder()
+                .id(user.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static AuthResponseDTO.CheckNicknameResultDTO toCheckNicknameResultDTO(boolean isDuplicated) {
+        return AuthResponseDTO.CheckNicknameResultDTO.builder()
+                .isDuplicated(isDuplicated)
+                .build();
+    }
+
+    public static AuthResponseDTO.CheckIdResultDTO toCheckIdResultDTO(boolean isDuplicated) {
+        return AuthResponseDTO.CheckIdResultDTO.builder()
+                .isDuplicated(isDuplicated)
+                .build();
+    }
+
+    public static AuthResponseDTO.VerifyCodeResultDTO toVerifyCodeResultDTO(boolean isVerified) {
+        return AuthResponseDTO.VerifyCodeResultDTO.builder()
+                .isVerified(isVerified)
+                .build();
+    }
+}

--- a/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
@@ -28,6 +28,15 @@ public class UserConverter {
                 .build();
     }
 
+    public static AuthResponseDTO.LoginResultDTO toLoginResultDTO(User user, String accessToken, String refreshToken) {
+        return AuthResponseDTO.LoginResultDTO.builder()
+                .id(user.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+    }
+
     public static AuthResponseDTO.CheckNicknameResultDTO toCheckNicknameResultDTO(boolean isDuplicated) {
         return AuthResponseDTO.CheckNicknameResultDTO.builder()
                 .isDuplicated(isDuplicated)

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -27,7 +27,7 @@ public class User extends BaseEntity {
     @Column(length = 20, nullable = false)
     private String userId;
 
-    @Column(length = 20, nullable = false)
+    @Column(nullable = false)
     private String password;
 
     @Column(length = 30, nullable = false)
@@ -58,4 +58,8 @@ public class User extends BaseEntity {
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id", referencedColumnName = "id")
     private Image profileImage;
+
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -55,10 +55,6 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "VARCHAR(10) DEFAULT 'USER'", nullable = false)
     private Role role;
 
-    @ColumnDefault("FALSE")
-    @Column(name = "is_email_verified")
-    private Boolean isEmailVerified;
-
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id", referencedColumnName = "id")
     private Image profileImage;

--- a/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(String userId);
     boolean existsByNickname(String nickname);
     boolean existsByUserId(String userId);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
@@ -4,4 +4,6 @@ import com.otakumap.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByNickname(String nickname);
+    boolean existsByUserId(String userId);
 }

--- a/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
@@ -3,7 +3,10 @@ package com.otakumap.domain.user.repository;
 import com.otakumap.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUserId(String userId);
     boolean existsByNickname(String nickname);
     boolean existsByUserId(String userId);
 }

--- a/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/otakumap/domain/user/repository/UserRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(String userId);
+    Optional<User> findByEmail(String email);
     boolean existsByNickname(String nickname);
     boolean existsByUserId(String userId);
     boolean existsByEmail(String email);

--- a/src/main/java/com/otakumap/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserQueryService.java
@@ -3,5 +3,5 @@ package com.otakumap.domain.user.service;
 import com.otakumap.domain.user.entity.User;
 
 public interface UserQueryService {
-    User getUserByUserId(String userId);
+    User getUserByEmail(String email);
 }

--- a/src/main/java/com/otakumap/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserQueryService.java
@@ -1,0 +1,7 @@
+package com.otakumap.domain.user.service;
+
+import com.otakumap.domain.user.entity.User;
+
+public interface UserQueryService {
+    User getUserByUserId(String userId);
+}

--- a/src/main/java/com/otakumap/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserQueryServiceImpl.java
@@ -1,0 +1,19 @@
+package com.otakumap.domain.user.service;
+
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.repository.UserRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.AuthHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+    private final UserRepository userRepository;
+
+    @Override
+    public User getUserByUserId(String userId) {
+        return userRepository.findByUserId(userId).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/otakumap/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserQueryServiceImpl.java
@@ -13,7 +13,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     private final UserRepository userRepository;
 
     @Override
-    public User getUserByUserId(String userId) {
-        return userRepository.findByUserId(userId).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
@@ -16,6 +16,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+    // 인증 관련 에러
+    PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST, "AUTH4001", "비밀번호가 일치하지 않습니다."),
+    EMAIL_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH4002", "인증 코드가 만료되었습니다. 다시 요청해주세요."),
+    CODE_NOT_EQUAL(HttpStatus.BAD_REQUEST, "AUTH4003", "인증 코드가 올바르지 않습니다."),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "메일 발송 중 오류가 발생했습니다."),
+
     // 멤버 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
 
@@ -30,7 +36,6 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 명소 좋아요 관련 에러
     PLACE_LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PLACE4002", "저장되지 않은 명소입니다.");
-
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,9 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH4002", "인증 코드가 만료되었습니다. 다시 요청해주세요."),
     CODE_NOT_EQUAL(HttpStatus.BAD_REQUEST, "AUTH4003", "인증 코드가 올바르지 않습니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "메일 발송 중 오류가 발생했습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4004", "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4005", "토큰이 만료되었습니다."),
+    TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "AUTH4006", "이 토큰은 로그아웃되어 더 이상 유효하지 않습니다."),
 
     // 멤버 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),

--- a/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
@@ -21,9 +21,10 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH4002", "인증 코드가 만료되었습니다. 다시 요청해주세요."),
     CODE_NOT_EQUAL(HttpStatus.BAD_REQUEST, "AUTH4003", "인증 코드가 올바르지 않습니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "메일 발송 중 오류가 발생했습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4004", "유효하지 않은 토큰입니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4005", "토큰이 만료되었습니다."),
-    TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "AUTH4006", "이 토큰은 로그아웃되어 더 이상 유효하지 않습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "AUTH4004", "이미 사용 중인 이메일입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4005", "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4006", "토큰이 만료되었습니다."),
+    TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "AUTH4007", "이 토큰은 로그아웃되어 더 이상 유효하지 않습니다."),
 
     // 멤버 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),

--- a/src/main/java/com/otakumap/global/apiPayload/exception/handler/AuthHandler.java
+++ b/src/main/java/com/otakumap/global/apiPayload/exception/handler/AuthHandler.java
@@ -1,0 +1,10 @@
+package com.otakumap.global.apiPayload.exception.handler;
+
+import com.otakumap.global.apiPayload.code.BaseErrorCode;
+import com.otakumap.global.apiPayload.exception.GeneralException;
+
+public class AuthHandler extends GeneralException {
+  public AuthHandler(BaseErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/otakumap/global/config/AsyncConfig.java
+++ b/src/main/java/com/otakumap/global/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.otakumap.global.config;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "mailExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("Async MailExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return AsyncConfigurer.super.getAsyncUncaughtExceptionHandler();
+    }
+}

--- a/src/main/java/com/otakumap/global/config/MailConfig.java
+++ b/src/main/java/com/otakumap/global/config/MailConfig.java
@@ -1,0 +1,67 @@
+package com.otakumap.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private Integer port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/otakumap/global/config/RedisConfig.java
+++ b/src/main/java/com/otakumap/global/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.otakumap.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key:value의 경우 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Hash를 사용할 경우 시리얼라이저
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // 모든 경우
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/otakumap/global/config/SecurityConfig.java
+++ b/src/main/java/com/otakumap/global/config/SecurityConfig.java
@@ -1,45 +1,58 @@
 package com.otakumap.global.config;
 
+import com.otakumap.domain.auth.jwt.filter.JwtFilter;
+import com.otakumap.domain.auth.jwt.handler.JwtAccessDeniedHandler;
+import com.otakumap.domain.auth.jwt.handler.JwtAuthenticationEntryPoint;
+import com.otakumap.domain.auth.jwt.userdetails.PrincipalDetailsService;
+import com.otakumap.domain.auth.jwt.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtProvider jwtProvider;
+    private final PrincipalDetailsService principalDetailsService;
 
-    // 현재 oauth와 jwt 설정 안 해놔서 작동 안 하기 때문에 해당 코드는 주석처리함
-//    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-//    private final AuthenticationProvider authenticationProvider;
-//    private final CustomOAuth2UserService oAuth2UserService;
-//    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final String[] allowUrl = {
+            "/",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+            "/api/auth/**"
+    };
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                //crsf 보안 비활성화
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
-                        .requestMatchers("/", "/home", "/signup", "/members/signup", "/css/**").permitAll()
-                        .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated()
-                )
-//                .authenticationProvider(authenticationProvider)
-//                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-//                .oauth2Login(oauth2 -> oauth2
-//                        .loginPage("/login")
-//                        .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
-//                        .successHandler(oAuth2LoginSuccessHandler)
-//                )
-                  ;
-
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers(allowUrl).permitAll()
+                        .anyRequest().authenticated())
+                //기본 폼 로그인 비활성화
+                .formLogin((form) -> form.disable())
+                // BasicHttp 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable)
+                //JwtAuthFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
+                .addFilterBefore(new JwtFilter(jwtProvider, principalDetailsService), UsernamePasswordAuthenticationFilter.class)
+                // 예외 처리 설정
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                );
         return http.build();
     }
 

--- a/src/main/java/com/otakumap/global/config/SecurityConfig.java
+++ b/src/main/java/com/otakumap/global/config/SecurityConfig.java
@@ -5,13 +5,13 @@ import com.otakumap.domain.auth.jwt.handler.JwtAccessDeniedHandler;
 import com.otakumap.domain.auth.jwt.handler.JwtAuthenticationEntryPoint;
 import com.otakumap.domain.auth.jwt.userdetails.PrincipalDetailsService;
 import com.otakumap.domain.auth.jwt.util.JwtProvider;
+import com.otakumap.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -24,6 +24,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtProvider jwtProvider;
+    private final RedisUtil redisUtil;
     private final PrincipalDetailsService principalDetailsService;
 
     private final String[] allowUrl = {
@@ -47,7 +48,7 @@ public class SecurityConfig {
                 // BasicHttp 비활성화
                 .httpBasic(AbstractHttpConfigurer::disable)
                 //JwtAuthFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
-                .addFilterBefore(new JwtFilter(jwtProvider, principalDetailsService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtFilter(jwtProvider, redisUtil, principalDetailsService), UsernamePasswordAuthenticationFilter.class)
                 // 예외 처리 설정
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/com/otakumap/global/config/WebConfig.java
+++ b/src/main/java/com/otakumap/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.otakumap.global.config;
+
+import com.otakumap.domain.auth.jwt.resolver.AuthenticatedUserResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final AuthenticatedUserResolver authenticatedUserResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedUserResolver);
+    }
+}

--- a/src/main/java/com/otakumap/global/config/WebConfig.java
+++ b/src/main/java/com/otakumap/global/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.otakumap.global.config;
 
-import com.otakumap.domain.auth.jwt.resolver.AuthenticatedUserResolver;
+import com.otakumap.domain.auth.jwt.resolver.CurrentUserResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -11,7 +11,7 @@ import java.util.List;
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
-    private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final CurrentUserResolver authenticatedUserResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/java/com/otakumap/global/util/RedisUtil.java
+++ b/src/main/java/com/otakumap/global/util/RedisUtil.java
@@ -7,29 +7,32 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Service
 public class RedisUtil {
     private final RedisTemplate<String, Object> redisTemplate;
-    private final StringRedisTemplate stringRedisTemplate;
 
-    public String getData(String key) {
-        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
-        return valueOperations.get(key);
+    public void set(String key, Object value) {
+        redisTemplate.opsForValue().set(key, value);
     }
 
-    public boolean existData(String key) {
-        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
     }
 
-    public void setDataExpire(String key, String value, long duration) {
-        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
-        Duration expireDuration = Duration.ofSeconds(duration);
-        valueOperations.set(key, value, expireDuration);
+    public boolean exists(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
-    public void deleteData(String key) {
-        stringRedisTemplate.delete(key);
+    public void expire(String key, long timeout, TimeUnit unit) {
+        redisTemplate.expire(key, timeout, unit);
     }
+
+
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
 }

--- a/src/main/java/com/otakumap/global/util/RedisUtil.java
+++ b/src/main/java/com/otakumap/global/util/RedisUtil.java
@@ -1,0 +1,35 @@
+package com.otakumap.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        stringRedisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,25 @@ spring:
         hbm2ddl:
           auto: update
         default_batch_fetch_size: 1000
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_POST}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 1800000  # 30 * 60 * 1000 == 30?
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      repositories:
+        enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
         default_batch_fetch_size: 1000
   mail:
     host: ${MAIL_HOST}
-    port: ${MAIL_POST}
+    port: ${MAIL_PORT}
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}
     properties:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,8 +36,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
       repositories:
         enabled: false
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,9 +33,16 @@ spring:
           timeout: 5000
           writetimeout: 5000
     auth-code-expiration-millis: 1800000  # 30 * 60 * 1000 == 30?
+
   data:
     redis:
       host: localhost
       port: 6379
       repositories:
         enabled: false
+
+  jwt:
+    secret: ${JWT_SECRET}
+    token:
+      access-expiration-time: 3600000 #1시간
+      refresh-expiration-time: 604800000 #7일


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #20 

## 📝 작업 내용
- 일반 로그인, 로그아웃, 토큰 재발급 API를 구현했습니다.

## 💬 리뷰 요구사항
설정한 환경변수는 노션 백엔드 문서에 올려두겠습니다.
 
@CurrentUser 어노테이션을 구현하여 현재 로그인된 User를 가져올 수 있도록 하였습니다. 
구현할 때 사용하시면 될 것 같습니다👍
예시)
```
    public ApiResponse<EventLikeResponseDTO.EventLikePreViewListDTO> getEventLikeList(@CurrentUser User user, @RequestParam(required = false) Integer type, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
        return ApiResponse.onSuccess(eventLikeQueryService.getEventLikeList(user, type, lastId, limit));
    }
```
