### PR TITLE
Feat: 소셜 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+ 	// OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	implementation 'com.google.code.gson:gson'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/otakumap/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/otakumap/domain/auth/controller/AuthController.java
@@ -3,7 +3,7 @@ package com.otakumap.domain.auth.controller;
 import com.otakumap.domain.auth.dto.AuthRequestDTO;
 import com.otakumap.domain.auth.dto.AuthResponseDTO;
 import com.otakumap.domain.auth.jwt.dto.JwtDTO;
-import com.otakumap.domain.auth.service.AuthCommandService;
+import com.otakumap.domain.auth.service.*;
 import com.otakumap.domain.user.converter.UserConverter;
 import com.otakumap.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthCommandService authCommandService;
+    private final SocialAuthService socialAuthService;
 
     @Operation(summary = "회원가입", description = "회원가입 기능입니다.")
     @PostMapping("/signup")
@@ -67,5 +68,23 @@ public class AuthController {
     public ApiResponse<String> logout(HttpServletRequest request) {
         authCommandService.logout(request);
         return ApiResponse.onSuccess("로그아웃 되었습니다.");
+    }
+
+    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 입력받아 로그인을 처리합니다.")
+    @PostMapping("/social/kakao")
+    public ApiResponse<AuthResponseDTO.LoginResultDTO> kakaoLogin(@Valid @RequestBody AuthRequestDTO.SocialLoginDTO request) {
+        return ApiResponse.onSuccess(socialAuthService.login("kakao", request));
+    }
+
+    @Operation(summary = "구글 로그인", description = "구글 인가 코드를 입력받아 로그인을 처리합니다.")
+    @PostMapping("/social/google")
+    public ApiResponse<AuthResponseDTO.LoginResultDTO> googleLogin(@Valid @RequestBody AuthRequestDTO.SocialLoginDTO request) {
+        return ApiResponse.onSuccess(socialAuthService.login("google", request));
+    }
+
+    @Operation(summary = "네이버 로그인", description = "네이버 인가 코드를 입력받아 로그인을 처리합니다.")
+    @PostMapping("/social/naver")
+    public ApiResponse<AuthResponseDTO.LoginResultDTO> naverLogin(@Valid @RequestBody AuthRequestDTO.SocialLoginDTO request) {
+        return ApiResponse.onSuccess(socialAuthService.login("naver", request));
     }
 }

--- a/src/main/java/com/otakumap/domain/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/AuthRequestDTO.java
@@ -70,4 +70,10 @@ public class AuthRequestDTO {
         @NotNull
         String email;
     }
+
+    @Getter
+    public static class SocialLoginDTO {
+        @NotNull
+        String code;
+    }
 }

--- a/src/main/java/com/otakumap/domain/auth/dto/GoogleUserInfo.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/GoogleUserInfo.java
@@ -1,0 +1,9 @@
+package com.otakumap.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class GoogleUserInfo {
+    private String email;
+    private String name;
+}

--- a/src/main/java/com/otakumap/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/KakaoUserInfo.java
@@ -4,17 +4,11 @@ import lombok.Getter;
 
 @Getter
 public class KakaoUserInfo {
-    private Properties properties;
     private KakaoAccount kakao_account;
 
     @Getter
     public static class KakaoAccount {
         private String name;
         private String email;
-    }
-
-    @Getter
-    public static class Properties {
-        private String nickname;
     }
 }

--- a/src/main/java/com/otakumap/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,20 @@
+package com.otakumap.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUserInfo {
+    private Properties properties;
+    private KakaoAccount kakao_account;
+
+    @Getter
+    public static class KakaoAccount {
+        private String name;
+        private String email;
+    }
+
+    @Getter
+    public static class Properties {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/dto/NaverUserInfo.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/NaverUserInfo.java
@@ -9,7 +9,6 @@ public class NaverUserInfo {
     @Getter
     public static class Response {
         private String name;
-        private String nickname;
         private String email;
     }
 }

--- a/src/main/java/com/otakumap/domain/auth/dto/NaverUserInfo.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/NaverUserInfo.java
@@ -1,0 +1,15 @@
+package com.otakumap.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NaverUserInfo {
+    private Response response;
+
+    @Getter
+    public static class Response {
+        private String name;
+        private String nickname;
+        private String email;
+    }
+}

--- a/src/main/java/com/otakumap/domain/auth/service/SocialAuthService.java
+++ b/src/main/java/com/otakumap/domain/auth/service/SocialAuthService.java
@@ -1,0 +1,8 @@
+package com.otakumap.domain.auth.service;
+
+import com.otakumap.domain.auth.dto.AuthRequestDTO;
+import com.otakumap.domain.auth.dto.AuthResponseDTO;
+
+public interface SocialAuthService {
+    AuthResponseDTO.LoginResultDTO login(String provider, AuthRequestDTO.SocialLoginDTO request);
+}

--- a/src/main/java/com/otakumap/domain/auth/service/SocialAuthServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/auth/service/SocialAuthServiceImpl.java
@@ -1,0 +1,221 @@
+package com.otakumap.domain.auth.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.otakumap.domain.auth.dto.*;
+import com.otakumap.domain.auth.jwt.userdetails.PrincipalDetails;
+import com.otakumap.domain.auth.jwt.util.JwtProvider;
+import com.otakumap.domain.user.converter.UserConverter;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.repository.UserRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.AuthHandler;
+import com.otakumap.global.config.SocialProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigInteger;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SocialAuthServiceImpl implements SocialAuthService {
+    private final SocialProperties socialProperties;
+    private final RestTemplate restTemplate;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+    private final Gson gson;
+
+    @Override
+    public AuthResponseDTO.LoginResultDTO login(String provider, AuthRequestDTO.SocialLoginDTO request) {
+        // yml 파일의 social 아래 값을 자바 객체로 매핑
+        SocialProperties.ProviderProperties properties = getProviderProperties(provider);
+        
+        // 네이버 로그인을 위한 상태코드 생성
+        String state = null;
+        if(provider.equals("naver")) {
+            state = generateState();
+        }
+        
+        // 인가 코드를 이용하여 AccessToken 가져옴
+        String accessToken = getAccessToken(
+                URLDecoder.decode(request.getCode(), StandardCharsets.UTF_8),
+                properties.getClientId(),
+                properties.getClientSecret(),
+                properties.getRedirectUri(),
+                properties.getTokenUri(),
+                state // 네이버
+        );
+
+        // AccessToken을 사용하여 유저 정보를 가져옴
+        Object userInfo = getUserInfo(
+                accessToken,
+                properties.getUserInfoUri(),
+                getMethod(provider),
+                getUserInfoClass(provider)
+        );
+
+        return socialLogin(provider, userInfo);
+    }
+
+    // 인가 코드를 이용하여 AccessToken 가져옴
+    private String getAccessToken(String code, String clientId, String clientSecret, String redirectUri, String tokenUri, String state) {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+        // 네이버의 경우 state 값이 필수
+        if (state != null) {
+            body.add("state", state);
+        }
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(tokenUri, request, String.class);
+            if (response.getStatusCode() == HttpStatus.OK) {
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode jsonNode = objectMapper.readTree(response.getBody());
+                // JSON 응답에서 access_token을 추출
+                System.out.println(jsonNode);
+                return jsonNode.get("access_token").asText();
+            }
+        } catch (Exception e) {
+            throw new AuthHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+        throw new AuthHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+    }
+
+    // AccessToken을 사용하여 유저 정보를 가져옴
+    private <T> T getUserInfo(String accessToken, String userInfoUri, HttpMethod httpMethod, Class<T> userInfoClass) {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(userInfoUri, httpMethod, request, String.class);
+            if (response.getStatusCode() == HttpStatus.OK) {
+                // JSON 응답을 userInfoClass로 변환
+                System.out.println(response.getBody());
+                return gson.fromJson(response.getBody(), userInfoClass);
+            }
+        } catch (Exception e) {
+            throw new AuthHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+        throw new AuthHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+    }
+
+    // 회원가입 & 로그인
+    private <T> AuthResponseDTO.LoginResultDTO socialLogin(String provider, T userInfo){
+        Optional<User> userOptional = userRepository.findByEmail(getEmail(provider, userInfo));
+        User user;
+
+        if (userOptional.isEmpty()) {    // 회원가입
+            user = createUser(provider, userInfo);
+            userRepository.save(user);
+        } else {
+            user = userOptional.get();
+        }
+
+        // 로그인
+        PrincipalDetails memberDetails = new PrincipalDetails(user);
+
+        // 로그인 성공 시 토큰 생성
+        String accessToken = jwtProvider.createAccessToken(memberDetails, user.getId());
+        String refreshToken = jwtProvider.createRefreshToken(memberDetails, user.getId());
+
+        return UserConverter.toLoginResultDTO(user, accessToken, refreshToken);
+    }
+
+    // provider에 맞는 Properties를 반환
+    private SocialProperties.ProviderProperties getProviderProperties(String provider) {
+        switch (provider.toLowerCase()) {
+            case "naver":
+                return socialProperties.getNaver();
+            case "kakao":
+                return socialProperties.getKakao();
+            case "google":
+                return socialProperties.getGoogle();
+            default:
+                throw new AuthHandler(ErrorStatus.UNSUPPORTED_PROVIDER);
+        }
+    }
+
+    // provider에 맞는 클래스를 반환
+    private Class<?> getUserInfoClass(String provider) {
+        switch (provider.toLowerCase()) {
+            case "kakao":
+                return KakaoUserInfo.class;
+            case "google":
+                return GoogleUserInfo.class;
+            case "naver":
+                return NaverUserInfo.class;
+            default:
+                throw new AuthHandler(ErrorStatus.UNSUPPORTED_PROVIDER);
+        }
+    }
+
+    // provider에 맞는 HTTP method를 반환
+    private HttpMethod getMethod(String provider) {
+        switch (provider.toLowerCase()) {
+            case "kakao", "naver":
+                return HttpMethod.POST;
+            case "google":
+                return HttpMethod.GET;
+            default:
+                throw new AuthHandler(ErrorStatus.UNSUPPORTED_PROVIDER);
+        }
+    }
+
+    // provider에 맞는 email를 반환
+    private <T> String getEmail(String provider, T userInfo) {
+        switch (provider.toLowerCase()) {
+            case "kakao":
+                return ((KakaoUserInfo) userInfo).getKakao_account().getEmail();
+            case "google":
+                return ((GoogleUserInfo) userInfo).getEmail();
+            case "naver":
+                return ((NaverUserInfo) userInfo).getResponse().getEmail();
+            default:
+                throw new AuthHandler(ErrorStatus.UNSUPPORTED_PROVIDER);
+        }
+    }
+
+    // 네이버 로그인 시 상태코드가 필수값
+    private String generateState() {
+        SecureRandom random = new SecureRandom();
+        return new BigInteger(130, random).toString(32);
+    }
+
+    // provider에 맞는 User 생성
+    private <T> User createUser(String provider, T userInfo) {
+        switch (provider.toLowerCase()) {
+            case "kakao":
+                return UserConverter.toKakaoUser((KakaoUserInfo) userInfo);
+            case "google":
+                return UserConverter.toGoogleUser((GoogleUserInfo) userInfo);
+            case "naver":
+                return UserConverter.toNaverUser((NaverUserInfo) userInfo);
+            default:
+                throw new AuthHandler(ErrorStatus.UNSUPPORTED_PROVIDER);
+        }
+    }
+}

--- a/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
@@ -1,9 +1,9 @@
 package com.otakumap.domain.user.converter;
 
-import com.otakumap.domain.auth.dto.AuthRequestDTO;
-import com.otakumap.domain.auth.dto.AuthResponseDTO;
+import com.otakumap.domain.auth.dto.*;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.domain.user.entity.enums.Role;
+import com.otakumap.domain.user.entity.enums.SocialType;
 import com.otakumap.domain.user.entity.enums.UserStatus;
 
 import java.time.LocalDateTime;
@@ -52,6 +52,33 @@ public class UserConverter {
     public static AuthResponseDTO.VerifyCodeResultDTO toVerifyCodeResultDTO(boolean isVerified) {
         return AuthResponseDTO.VerifyCodeResultDTO.builder()
                 .isVerified(isVerified)
+                .build();
+    }
+
+    public static User toKakaoUser(KakaoUserInfo kakaoUserInfo) {
+        return User.builder()
+                .name(kakaoUserInfo.getKakao_account().getName())
+                .nickname(kakaoUserInfo.getProperties().getNickname())
+                .email(kakaoUserInfo.getKakao_account().getEmail())
+                .socialType(SocialType.KAKAO)
+                .build();
+    }
+
+    public static User toGoogleUser(GoogleUserInfo googleUserInfo) {
+        return User.builder()
+                .name(googleUserInfo.getName())
+                .nickname(googleUserInfo.getName())
+                .email(googleUserInfo.getEmail())
+                .socialType(SocialType.GOOGLE)
+                .build();
+    }
+
+    public static User toNaverUser(NaverUserInfo naverUserInfo) {
+        return User.builder()
+                .name(naverUserInfo.getResponse().getName())
+                .nickname(naverUserInfo.getResponse().getNickname())
+                .email(naverUserInfo.getResponse().getEmail())
+                .socialType(SocialType.NAVER)
                 .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
@@ -5,6 +5,7 @@ import com.otakumap.domain.user.entity.User;
 import com.otakumap.domain.user.entity.enums.Role;
 import com.otakumap.domain.user.entity.enums.SocialType;
 import com.otakumap.domain.user.entity.enums.UserStatus;
+import com.otakumap.global.util.UuidGenerator;
 
 import java.time.LocalDateTime;
 
@@ -58,7 +59,7 @@ public class UserConverter {
     public static User toKakaoUser(KakaoUserInfo kakaoUserInfo) {
         return User.builder()
                 .name(kakaoUserInfo.getKakao_account().getName())
-                .nickname(kakaoUserInfo.getProperties().getNickname())
+                .nickname(UuidGenerator.generateUuid())
                 .email(kakaoUserInfo.getKakao_account().getEmail())
                 .socialType(SocialType.KAKAO)
                 .build();
@@ -67,7 +68,7 @@ public class UserConverter {
     public static User toGoogleUser(GoogleUserInfo googleUserInfo) {
         return User.builder()
                 .name(googleUserInfo.getName())
-                .nickname(googleUserInfo.getName())
+                .nickname(UuidGenerator.generateUuid())
                 .email(googleUserInfo.getEmail())
                 .socialType(SocialType.GOOGLE)
                 .build();
@@ -76,7 +77,7 @@ public class UserConverter {
     public static User toNaverUser(NaverUserInfo naverUserInfo) {
         return User.builder()
                 .name(naverUserInfo.getResponse().getName())
-                .nickname(naverUserInfo.getResponse().getNickname())
+                .nickname(UuidGenerator.generateUuid())
                 .email(naverUserInfo.getResponse().getEmail())
                 .socialType(SocialType.NAVER)
                 .build();

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.otakumap.domain.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.otakumap.domain.image.entity.Image;
 import com.otakumap.domain.user.entity.enums.Role;
 import com.otakumap.domain.user.entity.enums.SocialType;
@@ -24,10 +25,10 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 20, nullable = false)
+    @Column(length = 20)
     private String userId;
 
-    @Column(nullable = false)
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
     @Column(length = 30, nullable = false)

--- a/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4005", "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4006", "토큰이 만료되었습니다."),
     TOKEN_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "AUTH4007", "이 토큰은 로그아웃되어 더 이상 유효하지 않습니다."),
+    UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH4008", "지원하지 않는 provider입니다."),
 
     // 멤버 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),

--- a/src/main/java/com/otakumap/global/config/SocialProperties.java
+++ b/src/main/java/com/otakumap/global/config/SocialProperties.java
@@ -1,0 +1,23 @@
+package com.otakumap.global.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "social") // yml 파일 'social' 아래 값을 바인딩
+public class SocialProperties {
+    private ProviderProperties kakao; // 'kakao' 관련 값
+    private ProviderProperties google; // 'google' 관련 값
+    private ProviderProperties naver; // 'naver' 관련 값
+
+    @Data
+    public static class ProviderProperties {
+        private String clientId;
+        private String clientSecret;
+        private String redirectUri;
+        private String tokenUri;
+        private String userInfoUri;
+    }
+}

--- a/src/main/java/com/otakumap/global/config/WebConfig.java
+++ b/src/main/java/com/otakumap/global/config/WebConfig.java
@@ -2,7 +2,9 @@ package com.otakumap.global.config;
 
 import com.otakumap.domain.auth.jwt.resolver.CurrentUserResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,5 +18,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authenticatedUserResolver);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/otakumap/global/util/UuidGenerator.java
+++ b/src/main/java/com/otakumap/global/util/UuidGenerator.java
@@ -1,0 +1,36 @@
+package com.otakumap.global.util;
+
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.AuthHandler;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+public class UuidGenerator {
+    public static String generateUuid() {
+        // UUID를 문자열로 변환
+        String uuid = UUID.randomUUID().toString();
+
+        // 문자열을 UTF-8로 인코딩하여 바이트 배열로 변환
+        byte[] uuidBytes = uuid.getBytes(StandardCharsets.UTF_8);
+        byte[] hash;
+        try {
+            // SHA-256 해시 함수를 사용하여 바이트 배열 해싱
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            hash = digest.digest(uuidBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new AuthHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+        // 앞 4바이트를 16진수 문자열로 변환
+        StringBuilder uniqueId = new StringBuilder();
+        for (int i = 0; i < 4; i++) {
+            // 각 바이트를 2자리 16진수로 변환하여 결합
+            uniqueId.append(String.format("%02x", hash[i]));
+        }
+
+        // 최종적으로 8자리 고유값 생성
+        return uniqueId.toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,23 @@ spring:
     token:
       access-expiration-time: 3600000 #1시간
       refresh-expiration-time: 604800000 #7일
+
+social:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+    token-uri: ${KAKAO_TOKEN_URI}
+    user-info-uri: ${KAKAO_USERINFO_URI}
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
+    token-uri: ${GOOGLE_TOKEN_URI}
+    user-info-uri: ${GOOGLE_USERINFO_URI}
+  naver:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+    redirect-uri: ${NAVER_REDIRECT_URI}
+    token-uri: ${NAVER_TOKEN_URI}
+    user-info-uri: ${NAVER_USERINFO_URI}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #23 

## 📝 작업 내용
- 프론트에서 인가 코드를 받고 코드를 통해 accessToken을 발급받고 회원가입 및 로그인을 진행하는 방식으로 구현하였습니다.
- 소셜 로그인 시 유저 아이디, 비밀번호 설정이 불필요하기 때문에 선택적 필드로 변경하였습니다.

## 💬 리뷰 요구사항
- PM, 프론트 분과 상의 후 아래와 같이 구현하였습니다.

1. 소셜 로그인과 일반 로그인 통합
2. 닉네임이 제공되지 않는 구글의 경우 실명을 닉네임으로 설정한 후 마이페이지에서 수정하는 방향으로 진행

- 설정한 환경변수는 백엔드 문서에 적어두겠습니다
