### PR TITLE
Feat: 회원 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/notification/entity/Notification.java
+++ b/src/main/java/com/otakumap/domain/notification/entity/Notification.java
@@ -1,33 +1,38 @@
 package com.otakumap.domain.notification.entity;
 
 import com.otakumap.domain.user.entity.User;
+import com.otakumap.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Notification {
+public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ColumnDefault("true")
-    private Boolean community_activity;
+    @Column(nullable = false)
+    private String type;
 
-    @ColumnDefault("true")
-    private Boolean event_benefits_info;
+    @Column(nullable = false, length = 255)
+    private String message;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @Column(nullable = false)
+    private String url;
+
+    @Column(nullable = false)
+    private Boolean isRead = false;
+
+    private LocalDateTime readAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
-
-    public Notification(User user) {
-        this.user = user;
-        this.community_activity = true;
-        this.event_benefits_info = true;
-    }
 }

--- a/src/main/java/com/otakumap/domain/notification/entity/Notification.java
+++ b/src/main/java/com/otakumap/domain/notification/entity/Notification.java
@@ -1,0 +1,33 @@
+package com.otakumap.domain.notification.entity;
+
+import com.otakumap.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ColumnDefault("true")
+    private Boolean community_activity;
+
+    @ColumnDefault("true")
+    private Boolean event_benefits_info;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public Notification(User user) {
+        this.user = user;
+        this.community_activity = true;
+        this.event_benefits_info = true;
+    }
+}

--- a/src/main/java/com/otakumap/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/otakumap/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.otakumap.domain.notification.repository;
+
+import com.otakumap.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/otakumap/domain/user/contoller/UserController.java
+++ b/src/main/java/com/otakumap/domain/user/contoller/UserController.java
@@ -14,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/users")
 public class UserController {
     private final UserQueryService userQueryService;
 
-    @GetMapping("/users")
+    @GetMapping
     @Operation(summary = "회원 정보 조회 API", description = "회원 정보를 조회합니다.")
     public ApiResponse<UserResponseDTO.UserInfoResponseDTO> getUserInfo(@CurrentUser User user) {
         User userInfo = userQueryService.getUserInfo(user.getId());

--- a/src/main/java/com/otakumap/domain/user/contoller/UserController.java
+++ b/src/main/java/com/otakumap/domain/user/contoller/UserController.java
@@ -1,0 +1,27 @@
+package com.otakumap.domain.user.contoller;
+
+import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
+import com.otakumap.domain.user.converter.UserConverter;
+import com.otakumap.domain.user.dto.UserResponseDTO;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.service.UserQueryService;
+import com.otakumap.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+    private final UserQueryService userQueryService;
+
+    @GetMapping("/users")
+    @Operation(summary = "회원 정보 조회 API", description = "회원 정보를 조회합니다.")
+    public ApiResponse<UserResponseDTO.UserInfoResponseDTO> getUserInfo(@CurrentUser User user) {
+        User userInfo = userQueryService.getUserInfo(user.getId());
+        return ApiResponse.onSuccess(UserConverter.toUserInfoResponseDTO(userInfo));
+    }
+}

--- a/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
@@ -2,6 +2,7 @@ package com.otakumap.domain.user.converter;
 
 import com.otakumap.domain.auth.dto.AuthRequestDTO;
 import com.otakumap.domain.auth.dto.AuthResponseDTO;
+import com.otakumap.domain.user.dto.UserResponseDTO;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.domain.user.entity.enums.Role;
 import com.otakumap.domain.user.entity.enums.UserStatus;
@@ -52,6 +53,17 @@ public class UserConverter {
     public static AuthResponseDTO.VerifyCodeResultDTO toVerifyCodeResultDTO(boolean isVerified) {
         return AuthResponseDTO.VerifyCodeResultDTO.builder()
                 .isVerified(isVerified)
+                .build();
+    }
+
+    public static UserResponseDTO.UserInfoResponseDTO toUserInfoResponseDTO(User user) {
+        return UserResponseDTO.UserInfoResponseDTO.builder()
+                .profileImageUrl(user.getProfileImage() == null ? null : user.getProfileImage().getFileUrl())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .donation(user.getDonation())
+                .community_activity(user.getNotification().getCommunity_activity())
+                .event_benefits_info(user.getNotification().getEvent_benefits_info())
                 .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
@@ -17,6 +17,8 @@ public class UserConverter {
                 .userId(request.getUserId())
                 .email(request.getEmail())
                 .password(request.getPassword())
+                .isCommunityActivityNotified(true)
+                .isEventBenefitsNotified(true)
                 .role(Role.USER)
                 .status(UserStatus.ACTIVE)
                 .build();
@@ -62,8 +64,8 @@ public class UserConverter {
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .donation(user.getDonation())
-                .community_activity(user.getNotification().getCommunity_activity())
-                .event_benefits_info(user.getNotification().getEvent_benefits_info())
+                .community_activity(user.getIsCommunityActivityNotified())
+                .event_benefits_info(user.getIsEventBenefitsNotified())
                 .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/user/dto/UserResponseDTO.java
@@ -1,0 +1,21 @@
+package com.otakumap.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfoResponseDTO {
+        private String profileImageUrl;
+        private String nickname;
+        private String email;
+        private Integer donation;
+        private boolean community_activity;
+        private boolean event_benefits_info;
+    }
+}

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -48,6 +48,12 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Integer donation;
 
+    @Column(nullable = false)
+    private Boolean isCommunityActivityNotified = true;
+
+    @Column(nullable = false)
+    private Boolean isEventBenefitsNotified = true;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10) DEFAULT 'ACTIVE'", nullable = false)
     private UserStatus status;
@@ -63,8 +69,4 @@ public class User extends BaseEntity {
     public void encodePassword(String password) {
         this.password = password;
     }
-
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private Notification notification;
-
 }

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.otakumap.domain.user.entity;
 
 import com.otakumap.domain.image.entity.Image;
+import com.otakumap.domain.notification.entity.Notification;
 import com.otakumap.domain.user.entity.enums.Role;
 import com.otakumap.domain.user.entity.enums.SocialType;
 import com.otakumap.domain.user.entity.enums.UserStatus;
@@ -62,4 +63,8 @@ public class User extends BaseEntity {
     public void encodePassword(String password) {
         this.password = password;
     }
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Notification notification;
+
 }

--- a/src/main/java/com/otakumap/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserQueryService.java
@@ -4,4 +4,5 @@ import com.otakumap.domain.user.entity.User;
 
 public interface UserQueryService {
     User getUserByEmail(String email);
+    User getUserInfo(Long userId);
 }

--- a/src/main/java/com/otakumap/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserQueryServiceImpl.java
@@ -16,4 +16,9 @@ public class UserQueryServiceImpl implements UserQueryService {
     public User getUserByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
     }
+
+    @Override
+    public User getUserInfo(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new AuthHandler(ErrorStatus.USER_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #29 

## 📝 작업 내용
- 회원 정보 조회 API 구현
- User 엔티티에 수신 동의 여부 필드 추가
- UserController에 회원 정보 조회 엔드포인트 추가
- UserService에 회원 정보 조회 로직 구현
- 회원 정보 조회 DTO 생성
테스트 결과:
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/b75e0e77-5306-4923-97e1-40c8b9d225d7" />

## 💬 리뷰 요구사항
> 기존에 notification으로 분리되어있던 수신 동의 여부를 user의 컬럼으로 변경하였습니다. 
회원 정보 조회 시 반환되는 데이터 필드에 대해 추가나 제거가 필요한 부분이 있는지와,
현재 구현된 예외 처리 로직이 충분한지, 추가적으로 고려해야 할 예외 상황이 있는지 (토큰 기반으로 응답하기 때문에 따로 예외처리는 하지 않은 상태입니다!) 리뷰해주시면 좋을 것 같습니다!