### PR TITLE
Feat: 알림 설정 수정 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/user/contoller/UserController.java
+++ b/src/main/java/com/otakumap/domain/user/contoller/UserController.java
@@ -43,4 +43,13 @@ public class UserController {
         userCommandService.reportEvent(request);
         return ApiResponse.onSuccess("이벤트 제보가 성공적으로 전송되었습니다.");
     }
+
+    @PatchMapping("/notification-settings")
+    @Operation(summary = "알림 설정 변경 API", description = "회원의 알림 설정을 변경합니다.")
+    public ApiResponse<String> updateNotificationSettings(
+            @CurrentUser User user,
+            @Valid @RequestBody UserRequestDTO.NotificationSettingsRequestDTO request) {
+        userCommandService.updateNotificationSettings(user, request);
+        return ApiResponse.onSuccess("알림 설정이 성공적으로 업데이트되었습니다.");
+    }
 }

--- a/src/main/java/com/otakumap/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/user/dto/UserRequestDTO.java
@@ -1,13 +1,12 @@
 package com.otakumap.domain.user.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 
 public class UserRequestDTO {
     @Getter
     public static class UpdateNicknameDTO {
-        @NotBlank()
+        @NotBlank
         @Size(min = 1, max = 20, message = "닉네임은 1자 이상 20자 이하로 입력해주세요.")
         private String nickname;
     }
@@ -21,5 +20,16 @@ public class UserRequestDTO {
         private String animationName;
 
         private String additionalInfo;
+    }
+
+    @Getter
+    public static class NotificationSettingsRequestDTO {
+        @NotNull
+        @Min(value = 1, message = "알림 타입은 1 또는 2로 입력해주세요.")
+        @Max(value = 2, message = "알림 타입은 1 또는 2로 입력해주세요.")
+        private Integer notificationType;
+
+        @NotNull
+        private boolean isEnabled;
     }
 }

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -72,4 +72,9 @@ public class User extends BaseEntity {
     }
 
     public void setNickname(String nickname) { this.nickname = nickname; }
+
+    public void setNotification(Integer type, boolean isEnabled) {
+        if (type == 1) { this.isCommunityActivityNotified = isEnabled; }
+        else { this.isEventBenefitsNotified = isEnabled; }
+    }
 }

--- a/src/main/java/com/otakumap/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserCommandService.java
@@ -6,4 +6,5 @@ import com.otakumap.domain.user.entity.User;
 public interface UserCommandService {
     void updateNickname(User user, UserRequestDTO.UpdateNicknameDTO request);
     void reportEvent(UserRequestDTO.UserReportRequestDTO request);
+    void updateNotificationSettings(User user, UserRequestDTO.NotificationSettingsRequestDTO request);
 }

--- a/src/main/java/com/otakumap/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserCommandServiceImpl.java
@@ -40,4 +40,14 @@ public class UserCommandServiceImpl implements UserCommandService {
         // 이메일 전송
         emailUtil.sendEmail("otakumap0123@gmail.com", subject, content);
     }
+
+    @Override
+    @Transactional
+    public void updateNotificationSettings(User user, UserRequestDTO.NotificationSettingsRequestDTO request) {
+        if (request.getNotificationType() != 1 && request.getNotificationType() != 2) {
+            throw new UserHandler(ErrorStatus.INVALID_NOTIFICATION_TYPE);
+        }
+        user.setNotification(request.getNotificationType(), request.isEnabled());
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
@@ -44,7 +44,10 @@ public enum ErrorStatus implements BaseErrorCode {
     PLACE_LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PLACE4002", "저장되지 않은 명소입니다."),
 
     // 후기 검색 관련 에러
-    REVIEW_SEARCH_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH4001", "검색된 후기가 없습니다.");
+    REVIEW_SEARCH_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH4001", "검색된 후기가 없습니다."),
+
+    // 알림 관련 에러
+    INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "NOTIFICATION4001", "유효하지 않은 알림 타입입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #40 

## 📝 작업 내용
-   알림 설정 수정 API 구현 완료
- 알림 타입을 1(커뮤니티 활동 알림)과 2(이벤트 및 혜택 정보 알림)로 구분
- 각 알림 타입에 대해 true(ON) 또는 false(OFF) 설정 가능
- User 엔티티에 알림 설정 관련 필드 추가
- 유효성 검사 로직 구현 (올바른 notificationType 값인지 확인)

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/b19e5aa1-4670-4c18-a973-05b6c485c493" />
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/5b91e3d6-c5b8-4187-a5a9-026e5733a2f0" />