### PR TITLE
Feat: 저장한 이벤트 즐겨찾기/즐겨찾기 취소, 저장한 이벤트 즐겨찾기 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
+++ b/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
@@ -41,12 +41,12 @@ public class EventLikeController {
     @GetMapping( "")
     @Parameters({
             @Parameter(name = "type", description = "이벤트 타입 -> 1: 팝업 스토어, 2: 전시회, 3: 콜라보 카페"),
-            @Parameter(name = "isBookmarked", description = "북마크 여부(필수 X) -> true: 북마크 목록 조회"),
+            @Parameter(name = "isFavorite", description = "즐겨찾기 여부(필수 X) -> true: 즐겨찾기 목록 조회"),
             @Parameter(name = "lastId", description = "마지막으로 조회된 저장된 이벤트 id, 처음 가져올 때 -> 0"),
             @Parameter(name = "limit", description = "한 번에 조회할 최대 이벤트 수. 기본값은 10입니다.")
     })
-    public ApiResponse<EventLikeResponseDTO.EventLikePreViewListDTO> getEventLikeList(@CurrentUser User user, @RequestParam(required = false) Integer type, @RequestParam(required = false) Boolean isBookmarked, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
-        return ApiResponse.onSuccess(eventLikeQueryService.getEventLikeList(user, type, isBookmarked, lastId, limit));
+    public ApiResponse<EventLikeResponseDTO.EventLikePreViewListDTO> getEventLikeList(@CurrentUser User user, @RequestParam(required = false) Integer type, @RequestParam(required = false) Boolean isFavorite, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
+        return ApiResponse.onSuccess(eventLikeQueryService.getEventLikeList(user, type, isFavorite, lastId, limit));
     }
 
     @Operation(summary = "저장된 이벤트 삭제(이벤트 찜하기 취소)", description = "저장된 이벤트를 삭제합니다.")
@@ -61,7 +61,7 @@ public class EventLikeController {
 
     @Operation(summary = "저장된 이벤트 즐겨찾기/즐겨찾기 취소", description = "저장된 이벤트를 즐겨찾기 또는 취소합니다.")
     @PatchMapping("/{eventLikeId}/favorites")
-    public ApiResponse<EventLikeResponseDTO.BookmarkResultDTO> bookmarkEventLike(@PathVariable Long eventLikeId, @RequestBody @Valid EventLikeRequestDTO.FavoriteDTO request) {
-        return ApiResponse.onSuccess(EventLikeConverter.toBookmarkResultDTO(eventLikeCommandService.favoriteEventLike(eventLikeId, request)));
+    public ApiResponse<EventLikeResponseDTO.FavoriteResultDTO> favoriteEventLike(@PathVariable Long eventLikeId, @RequestBody @Valid EventLikeRequestDTO.FavoriteDTO request) {
+        return ApiResponse.onSuccess(EventLikeConverter.toFavoriteResultDTO(eventLikeCommandService.favoriteEventLike(eventLikeId, request)));
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
+++ b/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
@@ -37,15 +37,16 @@ public class EventLikeController {
         return ApiResponse.onSuccess("이벤트가 성공적으로 저장되었습니다.");
     }
 
-    @Operation(summary = "저장된 이벤트 목록 조회", description = "저장된 이벤트 목록을 불러옵니다.")
+    @Operation(summary = "저장된 이벤트 목록 조회(+ 즐겨찾기 목록 조회)", description = "저장된 이벤트 목록을 불러옵니다.")
     @GetMapping( "")
     @Parameters({
             @Parameter(name = "type", description = "이벤트 타입 -> 1: 팝업 스토어, 2: 전시회, 3: 콜라보 카페"),
+            @Parameter(name = "isBookmarked", description = "북마크 여부(필수 X) -> true: 북마크 목록 조회"),
             @Parameter(name = "lastId", description = "마지막으로 조회된 저장된 이벤트 id, 처음 가져올 때 -> 0"),
             @Parameter(name = "limit", description = "한 번에 조회할 최대 이벤트 수. 기본값은 10입니다.")
     })
-    public ApiResponse<EventLikeResponseDTO.EventLikePreViewListDTO> getEventLikeList(@CurrentUser User user, @RequestParam(required = false) Integer type, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
-        return ApiResponse.onSuccess(eventLikeQueryService.getEventLikeList(user, type, lastId, limit));
+    public ApiResponse<EventLikeResponseDTO.EventLikePreViewListDTO> getEventLikeList(@CurrentUser User user, @RequestParam(required = false) Integer type, @RequestParam(required = false) Boolean isBookmarked, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
+        return ApiResponse.onSuccess(eventLikeQueryService.getEventLikeList(user, type, isBookmarked, lastId, limit));
     }
 
     @Operation(summary = "저장된 이벤트 삭제(이벤트 찜하기 취소)", description = "저장된 이벤트를 삭제합니다.")

--- a/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
+++ b/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
@@ -1,6 +1,8 @@
 package com.otakumap.domain.event_like.controller;
 
 import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
+import com.otakumap.domain.event_like.converter.EventLikeConverter;
+import com.otakumap.domain.event_like.dto.EventLikeRequestDTO;
 import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import com.otakumap.domain.event_like.service.EventLikeCommandService;
 import com.otakumap.domain.event_like.service.EventLikeQueryService;
@@ -10,6 +12,7 @@ import com.otakumap.global.validation.annotation.ExistEventLike;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -45,7 +48,7 @@ public class EventLikeController {
         return ApiResponse.onSuccess(eventLikeQueryService.getEventLikeList(user, type, lastId, limit));
     }
 
-    @Operation(summary = "저장된 이벤트 삭제", description = "저장된 이벤트를 삭제합니다.")
+    @Operation(summary = "저장된 이벤트 삭제(이벤트 찜하기 취소)", description = "저장된 이벤트를 삭제합니다.")
     @DeleteMapping("")
     @Parameters({
             @Parameter(name = "eventIds", description = "저장된 이벤트 ID List"),
@@ -53,5 +56,11 @@ public class EventLikeController {
     public ApiResponse<String> deleteEventLike(@RequestParam(required = false) @ExistEventLike List<Long> eventIds) {
         eventLikeCommandService.deleteEventLike(eventIds);
         return ApiResponse.onSuccess("저장된 이벤트가 성공적으로 삭제되었습니다");
+    }
+
+    @Operation(summary = "저장된 이벤트 즐겨찾기/즐겨찾기 취소", description = "저장된 이벤트를 즐겨찾기 또는 취소합니다.")
+    @PatchMapping("/{eventLikeId}/bookmark")
+    public ApiResponse<EventLikeResponseDTO.BookmarkResultDTO> bookmarkEventLike(@PathVariable Long eventLikeId, @RequestBody @Valid EventLikeRequestDTO.BookmarkDTO request) {
+        return ApiResponse.onSuccess(EventLikeConverter.toBookmarkResultDTO(eventLikeCommandService.bookmarkEventLike(eventLikeId, request)));
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
+++ b/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
@@ -60,8 +60,8 @@ public class EventLikeController {
     }
 
     @Operation(summary = "저장된 이벤트 즐겨찾기/즐겨찾기 취소", description = "저장된 이벤트를 즐겨찾기 또는 취소합니다.")
-    @PatchMapping("/{eventLikeId}/bookmark")
-    public ApiResponse<EventLikeResponseDTO.BookmarkResultDTO> bookmarkEventLike(@PathVariable Long eventLikeId, @RequestBody @Valid EventLikeRequestDTO.BookmarkDTO request) {
-        return ApiResponse.onSuccess(EventLikeConverter.toBookmarkResultDTO(eventLikeCommandService.bookmarkEventLike(eventLikeId, request)));
+    @PatchMapping("/{eventLikeId}/favorites")
+    public ApiResponse<EventLikeResponseDTO.BookmarkResultDTO> bookmarkEventLike(@PathVariable Long eventLikeId, @RequestBody @Valid EventLikeRequestDTO.FavoriteDTO request) {
+        return ApiResponse.onSuccess(EventLikeConverter.toBookmarkResultDTO(eventLikeCommandService.favoriteEventLike(eventLikeId, request)));
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
@@ -17,7 +17,7 @@ public class EventLikeConverter {
                 .thumbnail(eventLike.getEvent().getThumbnailImage().getFileUrl())
                 .startDate(eventLike.getEvent().getStartDate())
                 .endDate(eventLike.getEvent().getEndDate())
-                .isFavorite(eventLike.getIsFavorite())
+                .isBookmarked(eventLike.getIsBookmarked())
                 .eventType(eventLike.getEvent().getType())
                 .build();
 
@@ -30,11 +30,18 @@ public class EventLikeConverter {
                 .build();
     }
 
-    public static EventLike eventLike(User user, Event event) {
+    public static EventLike toEventLike(User user, Event event) {
         return EventLike.builder()
                 .event(event)
                 .user(user)
-                .isFavorite(true)
+                .isBookmarked(false)
+                .build();
+    }
+
+    public static EventLikeResponseDTO.BookmarkResultDTO toBookmarkResultDTO(EventLike eventLike) {
+        return EventLikeResponseDTO.BookmarkResultDTO.builder()
+                .eventLikeId(eventLike.getId())
+                .isBookmarked(eventLike.getIsBookmarked())
                 .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
@@ -17,7 +17,7 @@ public class EventLikeConverter {
                 .thumbnail(eventLike.getEvent().getThumbnailImage().getFileUrl())
                 .startDate(eventLike.getEvent().getStartDate())
                 .endDate(eventLike.getEvent().getEndDate())
-                .isBookmarked(eventLike.getIsBookmarked())
+                .isFavorite(eventLike.getIsFavorite())
                 .eventType(eventLike.getEvent().getType())
                 .build();
 
@@ -34,14 +34,14 @@ public class EventLikeConverter {
         return EventLike.builder()
                 .event(event)
                 .user(user)
-                .isBookmarked(false)
+                .isFavorite(false)
                 .build();
     }
 
     public static EventLikeResponseDTO.BookmarkResultDTO toBookmarkResultDTO(EventLike eventLike) {
         return EventLikeResponseDTO.BookmarkResultDTO.builder()
                 .eventLikeId(eventLike.getId())
-                .isBookmarked(eventLike.getIsBookmarked())
+                .isFavorite(eventLike.getIsFavorite())
                 .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
@@ -38,8 +38,8 @@ public class EventLikeConverter {
                 .build();
     }
 
-    public static EventLikeResponseDTO.BookmarkResultDTO toBookmarkResultDTO(EventLike eventLike) {
-        return EventLikeResponseDTO.BookmarkResultDTO.builder()
+    public static EventLikeResponseDTO.FavoriteResultDTO toFavoriteResultDTO(EventLike eventLike) {
+        return EventLikeResponseDTO.FavoriteResultDTO.builder()
                 .eventLikeId(eventLike.getId())
                 .isFavorite(eventLike.getIsFavorite())
                 .build();

--- a/src/main/java/com/otakumap/domain/event_like/dto/EventLikeRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/event_like/dto/EventLikeRequestDTO.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 
 public class EventLikeRequestDTO {
     @Getter
-    public static class BookmarkDTO {
-        @NotNull(message = "북마크 여부 입력은 필수입니다.")
-        Boolean isBookmarked;
+    public static class FavoriteDTO {
+        @NotNull(message = "즐겨찾기 여부 입력은 필수입니다.")
+        Boolean isFavorite;
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/dto/EventLikeRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/event_like/dto/EventLikeRequestDTO.java
@@ -1,0 +1,13 @@
+package com.otakumap.domain.event_like.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class EventLikeRequestDTO {
+    @Getter
+    public static class BookmarkDTO {
+        @NotNull(message = "북마크 여부 입력은 필수입니다.")
+        Boolean isBookmarked;
+    }
+}

--- a/src/main/java/com/otakumap/domain/event_like/dto/EventLikeRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/event_like/dto/EventLikeRequestDTO.java
@@ -1,6 +1,5 @@
 package com.otakumap.domain.event_like.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 

--- a/src/main/java/com/otakumap/domain/event_like/dto/EventLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/event_like/dto/EventLikeResponseDTO.java
@@ -21,7 +21,7 @@ public class EventLikeResponseDTO {
         String thumbnail;
         LocalDate startDate;
         LocalDate endDate;
-        boolean isBookmarked;
+        Boolean isFavorite;
         EventType eventType;
     }
 
@@ -41,6 +41,6 @@ public class EventLikeResponseDTO {
     @AllArgsConstructor
     public static class BookmarkResultDTO {
         Long eventLikeId;
-        Boolean isBookmarked;
+        Boolean isFavorite;
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/dto/EventLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/event_like/dto/EventLikeResponseDTO.java
@@ -21,7 +21,7 @@ public class EventLikeResponseDTO {
         String thumbnail;
         LocalDate startDate;
         LocalDate endDate;
-        Boolean isFavorite;
+        boolean isBookmarked;
         EventType eventType;
     }
 
@@ -33,5 +33,14 @@ public class EventLikeResponseDTO {
         List<EventLikeResponseDTO.EventLikePreViewDTO> eventLikes;
         boolean hasNext;
         Long lastId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BookmarkResultDTO {
+        Long eventLikeId;
+        Boolean isBookmarked;
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/dto/EventLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/event_like/dto/EventLikeResponseDTO.java
@@ -39,7 +39,7 @@ public class EventLikeResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class BookmarkResultDTO {
+    public static class FavoriteResultDTO {
         Long eventLikeId;
         Boolean isFavorite;
     }

--- a/src/main/java/com/otakumap/domain/event_like/entity/EventLike.java
+++ b/src/main/java/com/otakumap/domain/event_like/entity/EventLike.java
@@ -29,7 +29,11 @@ public class EventLike extends BaseEntity {
     @JoinColumn(name = "event_id", nullable = false)
     private Event event;
 
-    @Column(name = "is_favorite", nullable = false)
+    @Column(name = "is_bookmarked", nullable = false)
     @ColumnDefault("false")
-    private Boolean isFavorite;
+    private Boolean isBookmarked;
+
+    public void setIsBookmarked(boolean isBookmarked) {
+        this.isBookmarked = isBookmarked;
+    }
 }

--- a/src/main/java/com/otakumap/domain/event_like/entity/EventLike.java
+++ b/src/main/java/com/otakumap/domain/event_like/entity/EventLike.java
@@ -29,11 +29,11 @@ public class EventLike extends BaseEntity {
     @JoinColumn(name = "event_id", nullable = false)
     private Event event;
 
-    @Column(name = "is_bookmarked", nullable = false)
+    @Column(name = "is_favorite", nullable = false)
     @ColumnDefault("false")
-    private Boolean isBookmarked;
+    private Boolean isFavorite;
 
-    public void setIsBookmarked(boolean isBookmarked) {
-        this.isBookmarked = isBookmarked;
+    public void setIsFavorite(boolean isFavorite) {
+        this.isFavorite = isFavorite;
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/repository/EventLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/event_like/repository/EventLikeRepository.java
@@ -1,17 +1,8 @@
 package com.otakumap.domain.event_like.repository;
 
-import com.otakumap.domain.event.entity.enums.EventType;
-import com.otakumap.domain.event_like.entity.EventLike;
-import com.otakumap.domain.user.entity.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import com.otakumap.domain.event_like.entity.EventLike;;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
 
 public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
-    Page<EventLike> findAllByUserIsOrderByCreatedAtDesc(User user, Pageable pageable);
-    Page<EventLike> findAllByUserIsAndCreatedAtLessThanOrderByCreatedAtDesc(User user, LocalDateTime createdAt, Pageable pageable);
-    Page<EventLike> findAllByUserIsAndEventTypeOrderByCreatedAtDesc(User user, EventType type, Pageable pageable);
-    Page<EventLike> findAllByUserIsAndEventTypeAndCreatedAtLessThanOrderByCreatedAtDesc(User user,  EventType type, LocalDateTime createdAt, Pageable pageable);
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandService.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandService.java
@@ -1,5 +1,7 @@
 package com.otakumap.domain.event_like.service;
 
+import com.otakumap.domain.event_like.dto.EventLikeRequestDTO;
+import com.otakumap.domain.event_like.entity.EventLike;
 import com.otakumap.domain.user.entity.User;
 
 import java.util.List;
@@ -7,4 +9,5 @@ import java.util.List;
 public interface EventLikeCommandService {
     void addEventLike(User user, Long eventId);
     void deleteEventLike(List<Long> eventIds);
+    EventLike bookmarkEventLike(Long eventLikeId, EventLikeRequestDTO.BookmarkDTO request);
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandService.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandService.java
@@ -9,5 +9,5 @@ import java.util.List;
 public interface EventLikeCommandService {
     void addEventLike(User user, Long eventId);
     void deleteEventLike(List<Long> eventIds);
-    EventLike bookmarkEventLike(Long eventLikeId, EventLikeRequestDTO.BookmarkDTO request);
+    EventLike favoriteEventLike(Long eventLikeId, EventLikeRequestDTO.FavoriteDTO request);
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
@@ -4,7 +4,6 @@ import com.otakumap.domain.event.entity.Event;
 import com.otakumap.domain.event.repository.EventRepository;
 import com.otakumap.domain.event_like.converter.EventLikeConverter;
 import com.otakumap.domain.event_like.dto.EventLikeRequestDTO;
-import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import com.otakumap.domain.event_like.entity.EventLike;
 import com.otakumap.domain.event_like.repository.EventLikeRepository;
 import com.otakumap.domain.user.entity.User;

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
@@ -39,9 +39,9 @@ public class EventLikeCommandServiceImpl implements EventLikeCommandService {
     }
 
     @Override
-    public EventLike bookmarkEventLike(Long eventLikeId, EventLikeRequestDTO.BookmarkDTO request) {
+    public EventLike favoriteEventLike(Long eventLikeId, EventLikeRequestDTO.FavoriteDTO request) {
         EventLike eventLike = eventLikeRepository.findById(eventLikeId).orElseThrow(() -> new EventHandler(ErrorStatus.EVENT_LIKE_NOT_FOUND));
-        eventLike.setIsBookmarked(request.getIsBookmarked());
+        eventLike.setIsFavorite(request.getIsFavorite());
         return eventLikeRepository.save(eventLike);
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
@@ -3,6 +3,9 @@ package com.otakumap.domain.event_like.service;
 import com.otakumap.domain.event.entity.Event;
 import com.otakumap.domain.event.repository.EventRepository;
 import com.otakumap.domain.event_like.converter.EventLikeConverter;
+import com.otakumap.domain.event_like.dto.EventLikeRequestDTO;
+import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
+import com.otakumap.domain.event_like.entity.EventLike;
 import com.otakumap.domain.event_like.repository.EventLikeRepository;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
@@ -24,13 +27,8 @@ public class EventLikeCommandServiceImpl implements EventLikeCommandService {
 
     @Override
     public void addEventLike(User user, Long eventId) {
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new EventHandler(ErrorStatus.EVENT_NOT_FOUND));
-        eventLikeRepository.save(
-                EventLikeConverter.eventLike(user, event)
-        );
-        entityManager.flush();
-        entityManager.clear();
+        Event event = eventRepository.findById(eventId).orElseThrow(() -> new EventHandler(ErrorStatus.EVENT_NOT_FOUND));
+        eventLikeRepository.save(EventLikeConverter.toEventLike(user, event));
     }
 
     @Override
@@ -38,5 +36,12 @@ public class EventLikeCommandServiceImpl implements EventLikeCommandService {
         eventLikeRepository.deleteAllByIdInBatch(eventIds);
         entityManager.flush();
         entityManager.clear();
+    }
+
+    @Override
+    public EventLike bookmarkEventLike(Long eventLikeId, EventLikeRequestDTO.BookmarkDTO request) {
+        EventLike eventLike = eventLikeRepository.findById(eventLikeId).orElseThrow(() -> new EventHandler(ErrorStatus.EVENT_LIKE_NOT_FOUND));
+        eventLike.setIsBookmarked(request.getIsBookmarked());
+        return eventLikeRepository.save(eventLike);
     }
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryService.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryService.java
@@ -4,6 +4,6 @@ import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import com.otakumap.domain.user.entity.User;
 
 public interface EventLikeQueryService {
-    EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(User user, Integer type, Long lastId, int limit);
+    EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(User user, Integer type, Boolean isBookmarked, Long lastId, int limit);
     boolean isEventLikeExist(Long id);
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryService.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryService.java
@@ -4,6 +4,6 @@ import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import com.otakumap.domain.user.entity.User;
 
 public interface EventLikeQueryService {
-    EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(User user, Integer type, Boolean isBookmarked, Long lastId, int limit);
+    EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(User user, Integer type, Boolean isFavorite, Long lastId, int limit);
     boolean isEventLikeExist(Long id);
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryServiceImpl.java
@@ -36,7 +36,8 @@ public class EventLikeQueryServiceImpl implements EventLikeQueryService {
             predicate.and(qEventLike.event.type.eq(eventType));
         }
 
-        if (isFavorite != null) {
+        // isFavorite이 true일 때만 검색 조건에 추가
+        if (isFavorite != null && isFavorite) {
             predicate.and(qEventLike .isFavorite.eq(isFavorite));
         }
 

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryServiceImpl.java
@@ -4,15 +4,12 @@ import com.otakumap.domain.event.entity.enums.EventType;
 import com.otakumap.domain.event_like.converter.EventLikeConverter;
 import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import com.otakumap.domain.event_like.entity.EventLike;
+import com.otakumap.domain.event_like.entity.QEventLike;
 import com.otakumap.domain.event_like.repository.EventLikeRepository;
 import com.otakumap.domain.user.entity.User;
-import com.otakumap.domain.user.repository.UserRepository;
-import com.otakumap.global.apiPayload.code.status.ErrorStatus;
-import com.otakumap.global.apiPayload.exception.handler.EventHandler;
-import com.otakumap.global.apiPayload.exception.handler.UserHandler;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,24 +21,38 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class EventLikeQueryServiceImpl implements EventLikeQueryService {
     private final EventLikeRepository eventLikeRepository;
-    private final UserRepository userRepository;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(User user, Integer type, Long lastId, int limit) {
-        List<EventLike> result;
-        Pageable pageable = PageRequest.of(0, limit + 1);
+    public EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(User user, Integer type, Boolean isBookmarked, Long lastId, int limit) {
         EventType eventType = (type == null || type == 0) ? null : EventType.values()[type - 1];
 
-        if (lastId.equals(0L)) {
-            result = (eventType == null)
-                    ? eventLikeRepository.findAllByUserIsOrderByCreatedAtDesc(user, pageable).getContent()
-                    : eventLikeRepository.findAllByUserIsAndEventTypeOrderByCreatedAtDesc(user, eventType, pageable).getContent();
-        } else {
-            EventLike eventLike = eventLikeRepository.findById(lastId).orElseThrow(() -> new EventHandler(ErrorStatus.EVENT_LIKE_NOT_FOUND));
-            result =  (eventType == null)
-                    ? eventLikeRepository.findAllByUserIsAndCreatedAtLessThanOrderByCreatedAtDesc(user, eventLike.getCreatedAt(), pageable).getContent()
-                    : eventLikeRepository.findAllByUserIsAndEventTypeAndCreatedAtLessThanOrderByCreatedAtDesc(user, eventType, eventLike.getCreatedAt(), pageable).getContent();
+        QEventLike qEventLike = QEventLike.eventLike;
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        predicate.and(qEventLike.user.eq(user));
+
+        if (eventType != null) {
+            predicate.and(qEventLike.event.type.eq(eventType));
         }
+
+        if (isBookmarked != null) {
+            predicate.and(qEventLike.isBookmarked.eq(isBookmarked));
+        }
+
+        if (lastId != null && lastId > 0) {
+            predicate.and(qEventLike.id.lt(lastId));
+        }
+
+        List<EventLike> result = jpaQueryFactory
+                .selectFrom(qEventLike)
+                .leftJoin(qEventLike.event).fetchJoin()
+                .leftJoin(qEventLike.user).fetchJoin()
+                .where(predicate)
+                .orderBy(qEventLike.createdAt.desc())
+                .limit(limit + 1)
+                .fetch();
+
         return createEventLikePreviewListDTO(result, limit);
     }
 

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeQueryServiceImpl.java
@@ -24,7 +24,7 @@ public class EventLikeQueryServiceImpl implements EventLikeQueryService {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(User user, Integer type, Boolean isBookmarked, Long lastId, int limit) {
+    public EventLikeResponseDTO.EventLikePreViewListDTO getEventLikeList(User user, Integer type, Boolean isFavorite, Long lastId, int limit) {
         EventType eventType = (type == null || type == 0) ? null : EventType.values()[type - 1];
 
         QEventLike qEventLike = QEventLike.eventLike;
@@ -36,8 +36,8 @@ public class EventLikeQueryServiceImpl implements EventLikeQueryService {
             predicate.and(qEventLike.event.type.eq(eventType));
         }
 
-        if (isBookmarked != null) {
-            predicate.and(qEventLike.isBookmarked.eq(isBookmarked));
+        if (isFavorite != null) {
+            predicate.and(qEventLike .isFavorite.eq(isFavorite));
         }
 
         if (lastId != null && lastId > 0) {
@@ -55,7 +55,6 @@ public class EventLikeQueryServiceImpl implements EventLikeQueryService {
 
         return createEventLikePreviewListDTO(result, limit);
     }
-
 
     private EventLikeResponseDTO.EventLikePreViewListDTO createEventLikePreviewListDTO(List<EventLike> eventLikes, int limit) {
         boolean hasNext = eventLikes.size() > limit;


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #2 

## 📝 작업 내용
- 저장한 이벤트 즐겨찾기/즐겨찾기 취소, 저장한 이벤트 즐겨찾기 목록 조회 API를 구현했습니다.

## 💬 리뷰 요구사항
QueryDSL을 사용해서 목록 조회를 구현했는데, 사용이 익숙지 않아서 이 부분 봐주셨음 좋겠습니다!
