### PR TITLE
Feat: 진행 중인 인기 이벤트 조회 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/event/controller/EventController.java
+++ b/src/main/java/com/otakumap/domain/event/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.otakumap.domain.event.controller;
 
 import com.otakumap.domain.event.dto.EventResponseDTO;
+import com.otakumap.domain.event.service.EventCustomService;
 import com.otakumap.domain.event.service.EventQueryService;
 import com.otakumap.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -19,6 +22,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class EventController {
 
     private final EventQueryService eventQueryService;
+    private final EventCustomService eventCustomService;
+
+    @Operation(summary = "진행 중인 인기 이벤트 조회", description = "진행 중인 인기 이벤트의 목록(8개)를 불러옵니다.")
+    @GetMapping("/events/popular")
+    public ApiResponse<List<EventResponseDTO.EventDTO>> getEventDetail() {
+        return ApiResponse.onSuccess(eventCustomService.getPopularEvents());
+    }
 
     @Operation(summary = "이벤트 상세 정보 조회", description = "특정 이벤트의 상세 정보를 불러옵니다.")
     @GetMapping("/events/{eventId}/details")

--- a/src/main/java/com/otakumap/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/otakumap/domain/event/converter/EventConverter.java
@@ -7,6 +7,16 @@ import com.otakumap.domain.image.converter.ImageConverter;
 
 public class EventConverter {
 
+    public static EventResponseDTO.EventDTO toEventDTO(Event event) {
+        return EventResponseDTO.EventDTO.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .thumbnail(ImageConverter.toImageDTO(event.getThumbnailImage()))
+                .startDate(event.getStartDate())
+                .endDate(event.getEndDate())
+                .build();
+    }
+
     public static EventResponseDTO.EventDetailDTO toEventDetailDTO(Event event) {
         return EventResponseDTO.EventDetailDTO.builder()
                 .id(event.getId())

--- a/src/main/java/com/otakumap/domain/event/dto/EventResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/event/dto/EventResponseDTO.java
@@ -15,6 +15,18 @@ public class EventResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class EventDTO {
+        Long id;
+        String title;
+        LocalDate startDate;
+        LocalDate endDate;
+        ImageResponseDTO.ImageDTO thumbnail;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class EventDetailDTO {
         Long id;
         String title;

--- a/src/main/java/com/otakumap/domain/event/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/otakumap/domain/event/repository/EventRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.otakumap.domain.event.repository;
+
+import com.otakumap.domain.event.dto.EventResponseDTO;
+import java.util.List;
+
+public interface EventRepositoryCustom {
+    List<EventResponseDTO.EventDTO> getPopularEvents();
+}

--- a/src/main/java/com/otakumap/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/otakumap/domain/event/repository/EventRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.otakumap.domain.event.repository;
+
+import com.otakumap.domain.event.converter.EventConverter;
+import com.otakumap.domain.event.dto.EventResponseDTO;
+import com.otakumap.domain.event.entity.Event;
+import com.otakumap.domain.event.entity.QEvent;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class EventRepositoryImpl implements EventRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<EventResponseDTO.EventDTO> getPopularEvents() {
+        QEvent event = QEvent.event;
+
+        List<Event> events = queryFactory.selectFrom(event)
+                .where(event.endDate.goe(LocalDate.now())
+                        .and(event.startDate.loe(LocalDate.now())))
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(8)
+                .fetch();
+
+        return events.stream()
+                .map(EventConverter::toEventDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/otakumap/domain/event/service/EventCustomService.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventCustomService.java
@@ -1,0 +1,9 @@
+package com.otakumap.domain.event.service;
+
+import com.otakumap.domain.event.dto.EventResponseDTO;
+
+import java.util.List;
+
+public interface EventCustomService {
+    List<EventResponseDTO.EventDTO> getPopularEvents();
+}

--- a/src/main/java/com/otakumap/domain/event/service/EventCustomServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventCustomServiceImpl.java
@@ -1,0 +1,20 @@
+package com.otakumap.domain.event.service;
+
+import com.otakumap.domain.event.dto.EventResponseDTO;
+import com.otakumap.domain.event.repository.EventRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventCustomServiceImpl implements EventCustomService {
+    private final EventRepositoryCustom eventRepository;
+
+    @Override
+    public List<EventResponseDTO.EventDTO> getPopularEvents() {
+        return eventRepository.getPopularEvents();
+    }
+}

--- a/src/main/java/com/otakumap/domain/event/service/EventQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventQueryServiceImpl.java
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #89 

## 📝 작업 내용
- 현재 진행 중인 이벤트 목록을 랜덤으로 8개 조회할 수 있는 api를 구현합니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
`.orderBy(NumberExpression.random().asc())` 는 mySql에서 지원이 안 되기 때문에 다른 코드로 대체하여 사용하였습니다.
<img width="974" alt="Screenshot 2025-01-29 at 17 04 10" src="https://github.com/user-attachments/assets/c6c544f9-158f-425f-abb8-e0b6194e657f" />
