### PR TITLE
Feat: 메인 화면 배너 이미지 불러오기 api 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/event/controller/EventController.java
+++ b/src/main/java/com/otakumap/domain/event/controller/EventController.java
@@ -3,6 +3,8 @@ package com.otakumap.domain.event.controller;
 import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.event.service.EventCustomService;
 import com.otakumap.domain.event.service.EventQueryService;
+import com.otakumap.domain.image.dto.ImageResponseDTO;
+import com.otakumap.domain.image.entity.Image;
 import com.otakumap.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -35,5 +37,11 @@ public class EventController {
     @Parameter(name = "eventId", description = "이벤트 Id")
     public ApiResponse<EventResponseDTO.EventDetailDTO> getEventDetail(@PathVariable Long eventId) {
         return ApiResponse.onSuccess(eventQueryService.getEventDetail(eventId));
+    }
+
+    @Operation(summary = "홈 화면 이벤트 배너 조회", description = "홈 화면에 띄울 배너 이미지를 불러옵니다.")
+    @GetMapping("/events/banner")
+    public ApiResponse<ImageResponseDTO.ImageDTO> getBanner() {
+        return ApiResponse.onSuccess(eventCustomService.getEventBanner());
     }
 }

--- a/src/main/java/com/otakumap/domain/event/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/otakumap/domain/event/repository/EventRepositoryCustom.java
@@ -1,8 +1,11 @@
 package com.otakumap.domain.event.repository;
 
 import com.otakumap.domain.event.dto.EventResponseDTO;
+import com.otakumap.domain.image.dto.ImageResponseDTO;
+
 import java.util.List;
 
 public interface EventRepositoryCustom {
     List<EventResponseDTO.EventDTO> getPopularEvents();
+    ImageResponseDTO.ImageDTO getEventBanner();
 }

--- a/src/main/java/com/otakumap/domain/event/service/EventCustomService.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventCustomService.java
@@ -1,9 +1,11 @@
 package com.otakumap.domain.event.service;
 
 import com.otakumap.domain.event.dto.EventResponseDTO;
+import com.otakumap.domain.image.dto.ImageResponseDTO;
 
 import java.util.List;
 
 public interface EventCustomService {
     List<EventResponseDTO.EventDTO> getPopularEvents();
+    ImageResponseDTO.ImageDTO getEventBanner();
 }

--- a/src/main/java/com/otakumap/domain/event/service/EventCustomServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventCustomServiceImpl.java
@@ -2,6 +2,7 @@ package com.otakumap.domain.event.service;
 
 import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.event.repository.EventRepositoryCustom;
+import com.otakumap.domain.image.dto.ImageResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,5 +17,10 @@ public class EventCustomServiceImpl implements EventCustomService {
     @Override
     public List<EventResponseDTO.EventDTO> getPopularEvents() {
         return eventRepository.getPopularEvents();
+    }
+
+    @Override
+    public ImageResponseDTO.ImageDTO getEventBanner() {
+        return eventRepository.getEventBanner();
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #102 

## 📝 작업 내용

<img width="468" alt="Screenshot 2025-02-01 at 18 32 34" src="https://github.com/user-attachments/assets/b6f68c71-3c69-4432-98ee-0d2d77a2a390" />

- 진행 중인 이벤트 중 랜덤으로 썸네일 이미지를 배너로 사용합니다. 배너로 사용될 이미지를 조회하는 API를 구현하였습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<img width="969" alt="Screenshot 2025-02-01 at 18 29 04" src="https://github.com/user-attachments/assets/7e32d876-9769-4bc8-a669-8ea671a01921" />
NullPointerException을 피하기 위해
1. 현재 진행 중이며 thumbnail 이미지 데이터가 존재하는 이벤트 중 랜덤으로 고르도록 구현하였습니다.
<img width="448" alt="Screenshot 2025-02-01 at 18 29 59" src="https://github.com/user-attachments/assets/9f2215c4-d21e-4328-b9ba-ff4a66037b35" />
2. 진행하고 있는 이벤트가 없을 경우 디폴트 배너 이미지를 반환할 예정입니다. (아직 링크가 없어 이렇게만 작업해두었습니다)