### PR TITLE
Feat: 저장된 장소 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/animation/repository/AnimationRepository.java
+++ b/src/main/java/com/otakumap/domain/animation/repository/AnimationRepository.java
@@ -1,0 +1,7 @@
+package com.otakumap.domain.animation.repository;
+
+import com.otakumap.domain.animation.entity.Animation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimationRepository extends JpaRepository<Animation, Long> {
+}

--- a/src/main/java/com/otakumap/domain/animation/service/AnimationQueryService.java
+++ b/src/main/java/com/otakumap/domain/animation/service/AnimationQueryService.java
@@ -1,0 +1,5 @@
+package com.otakumap.domain.animation.service;
+
+public interface AnimationQueryService {
+    boolean existsById(Long animationId);
+}

--- a/src/main/java/com/otakumap/domain/animation/service/AnimationQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/animation/service/AnimationQueryServiceImpl.java
@@ -1,0 +1,16 @@
+package com.otakumap.domain.animation.service;
+
+import com.otakumap.domain.animation.repository.AnimationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnimationQueryServiceImpl implements AnimationQueryService {
+    private final AnimationRepository animationRepository;
+
+    @Override
+    public boolean existsById(Long animationId) {
+        return animationRepository.existsById(animationId);
+    }
+}

--- a/src/main/java/com/otakumap/domain/hash_tag/entity/HashTag.java
+++ b/src/main/java/com/otakumap/domain/hash_tag/entity/HashTag.java
@@ -1,8 +1,12 @@
 package com.otakumap.domain.hash_tag.entity;
 
+import com.otakumap.domain.mapping.PlaceAnimationHashTag;
 import com.otakumap.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,4 +21,7 @@ public class HashTag extends BaseEntity {
 
     @Column(nullable = false, length = 20)
     private String name;
+
+    @OneToMany(mappedBy = "hashTag", cascade = CascadeType.ALL)
+    private List<PlaceAnimationHashTag> placeAnimationHashTags = new ArrayList<>();
 }

--- a/src/main/java/com/otakumap/domain/mapping/PlaceAnimation.java
+++ b/src/main/java/com/otakumap/domain/mapping/PlaceAnimation.java
@@ -2,9 +2,13 @@ package com.otakumap.domain.mapping;
 
 import com.otakumap.domain.animation.entity.Animation;
 import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -24,4 +28,10 @@ public class PlaceAnimation extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "animation_id")
     private Animation animation;
+
+    @OneToMany(mappedBy = "placeAnimation", cascade = CascadeType.ALL)
+    private List<PlaceAnimationHashTag> placeAnimationHashTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "placeAnimation", cascade = CascadeType.ALL)
+    private List<PlaceLike> placeLikes = new ArrayList<>();
 }

--- a/src/main/java/com/otakumap/domain/mapping/PlaceAnimationHashTag.java
+++ b/src/main/java/com/otakumap/domain/mapping/PlaceAnimationHashTag.java
@@ -1,7 +1,6 @@
 package com.otakumap.domain.mapping;
 
 import com.otakumap.domain.hash_tag.entity.HashTag;
-import com.otakumap.domain.place.entity.Place;
 import com.otakumap.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,15 +10,14 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class PlaceHashTag extends BaseEntity {
-
+public class PlaceAnimationHashTag extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "place_id")
-    private Place place;
+    @JoinColumn(name = "place_animation_id")
+    private PlaceAnimation placeAnimation;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hash_tag_id")

--- a/src/main/java/com/otakumap/domain/place/entity/Place.java
+++ b/src/main/java/com/otakumap/domain/place/entity/Place.java
@@ -1,7 +1,6 @@
 package com.otakumap.domain.place.entity;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
-import com.otakumap.domain.mapping.PlaceHashTag;
 import com.otakumap.domain.place_short_review.entity.PlaceShortReview;
 import com.otakumap.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -44,8 +43,4 @@ public class Place extends BaseEntity {
 
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL)
     private List<PlaceAnimation> placeAnimationList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL)
-    private List<PlaceHashTag> placeHashTagList = new ArrayList<>();
-
 }

--- a/src/main/java/com/otakumap/domain/place_animation/repository/PlaceAnimationRepository.java
+++ b/src/main/java/com/otakumap/domain/place_animation/repository/PlaceAnimationRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface PlaceAnimationRepository extends JpaRepository<PlaceAnimation, Long> {
     Optional<PlaceAnimation> findByIdAndPlaceId(Long id, Long placeId);
+    Optional<PlaceAnimation> findByPlaceIdAndAnimationId(Long placeId, Long animationId);
 }

--- a/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
+++ b/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
@@ -8,7 +8,10 @@ import com.otakumap.domain.place_like.service.PlaceLikeCommandService;
 import com.otakumap.domain.place_like.service.PlaceLikeQueryService;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.ApiResponse;
+
+import com.otakumap.global.validation.annotation.ExistPlace;
 import com.otakumap.global.validation.annotation.ExistPlaceLike;
+import com.otakumap.global.validation.annotation.ExistPlaceListLike;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -42,7 +45,7 @@ public class PlaceLikeController {
     @Parameters({
             @Parameter(name = "placeIds", description = "저장된 장소 id List"),
     })
-    public ApiResponse<String> deletePlaceLike(@RequestParam(required = false) @ExistPlaceLike List<Long> placeIds) {
+    public ApiResponse<String> deletePlaceLike(@RequestParam(required = false) @ExistPlaceListLike List<Long> placeIds) {
         placeLikeCommandService.deletePlaceLike(placeIds);
         return ApiResponse.onSuccess("저장된 장소가 성공적으로 삭제되었습니다");
     }
@@ -52,10 +55,8 @@ public class PlaceLikeController {
     @Parameters({
             @Parameter(name = "placeId", description = "장소 Id")
     })
-    public ApiResponse<String> savePlaceLike(@PathVariable Long placeId, @CurrentUser User user) {
-
-         placeLikeCommandService.savePlaceLike(user, placeId);
-
+    public ApiResponse<String> savePlaceLike(@ExistPlace @PathVariable Long placeId, @CurrentUser User user, @RequestBody @Valid PlaceLikeRequestDTO.SavePlaceLikeDTO request) {
+         placeLikeCommandService.savePlaceLike(user, placeId, request);
          return ApiResponse.onSuccess("장소가 성공적으로 저장되었습니다.");
     }
 
@@ -63,5 +64,11 @@ public class PlaceLikeController {
     @PatchMapping("/{placeLikeId}/favorites")
     public ApiResponse<PlaceLikeResponseDTO.FavoriteResultDTO> favoritePlaceLike(@PathVariable Long placeLikeId, @RequestBody @Valid PlaceLikeRequestDTO.FavoriteDTO request) {
         return ApiResponse.onSuccess(PlaceLikeConverter.toFavoriteResultDTO(placeLikeCommandService.favoritePlaceLike(placeLikeId, request)));
+    }
+
+    @Operation(summary = "저장된 장소 상세 조회", description = "지도에서 저장된 장소의 정보를 확인합니다.")
+    @GetMapping("/{placeLikeId}")
+    public ApiResponse<PlaceLikeResponseDTO.PlaceLikeDetailDTO> getPlaceLike(@PathVariable @ExistPlaceLike Long placeLikeId) {
+        return ApiResponse.onSuccess(PlaceLikeConverter.placeLikeDetailDTO(placeLikeQueryService.getPlaceLike(placeLikeId)));
     }
 }

--- a/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
+++ b/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
@@ -69,6 +69,6 @@ public class PlaceLikeController {
     @Operation(summary = "저장된 장소 상세 조회", description = "지도에서 저장된 장소의 정보를 확인합니다.")
     @GetMapping("/{placeLikeId}")
     public ApiResponse<PlaceLikeResponseDTO.PlaceLikeDetailDTO> getPlaceLike(@PathVariable @ExistPlaceLike Long placeLikeId) {
-        return ApiResponse.onSuccess(PlaceLikeConverter.placeLikeDetailDTO(placeLikeQueryService.getPlaceLike(placeLikeId)));
+        return ApiResponse.onSuccess(placeLikeQueryService.getPlaceLike(placeLikeId));
     }
 }

--- a/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
+++ b/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
@@ -55,7 +55,7 @@ public class PlaceLikeController {
     @Parameters({
             @Parameter(name = "placeId", description = "장소 Id")
     })
-    public ApiResponse<String> savePlaceLike(@ExistPlace @PathVariable Long placeId, @CurrentUser User user, @RequestBody @Valid PlaceLikeRequestDTO.SavePlaceLikeDTO request) {
+    public ApiResponse<String> savePlaceLike(@ExistPlace @PathVariable Long placeId, @CurrentUser User user, @RequestBody @Validated PlaceLikeRequestDTO.SavePlaceLikeDTO request) {
          placeLikeCommandService.savePlaceLike(user, placeId, request);
          return ApiResponse.onSuccess("장소가 성공적으로 저장되었습니다.");
     }

--- a/src/main/java/com/otakumap/domain/place_like/converter/PlaceLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/place_like/converter/PlaceLikeConverter.java
@@ -2,6 +2,7 @@ package com.otakumap.domain.place_like.converter;
 
 import com.otakumap.domain.hash_tag.converter.HashTagConverter;
 import com.otakumap.domain.mapping.PlaceAnimation;
+import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.place_like.dto.PlaceLikeResponseDTO;
 import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
@@ -9,14 +10,14 @@ import com.otakumap.domain.user.entity.User;
 import java.util.List;
 
 public class PlaceLikeConverter {
-    public static PlaceLikeResponseDTO.PlaceLikePreViewDTO placeLikePreViewDTO(PlaceLike placeLike) {
+    public static PlaceLikeResponseDTO.PlaceLikePreViewDTO placeLikePreViewDTO(PlaceLike placeLike, Place place) {
         return PlaceLikeResponseDTO.PlaceLikePreViewDTO.builder()
                 .id(placeLike.getId())
-                .placeId(placeLike.getPlaceAnimation().getPlace().getId())
-                .name(placeLike.getPlaceAnimation().getPlace().getName())
-                .detail(placeLike.getPlaceAnimation().getPlace().getDetail())
-                .lat(placeLike.getPlaceAnimation().getPlace().getLat())
-                .lng(placeLike.getPlaceAnimation().getPlace().getLng())
+                .placeId(place.getId())
+                .name(place.getName())
+                .detail(place.getDetail())
+                .lat(place.getLat())
+                .lng(place.getLng())
                 .isFavorite(placeLike.getIsFavorite())
                 .build();
 
@@ -45,13 +46,13 @@ public class PlaceLikeConverter {
                 .build();
     }
 
-    public static PlaceLikeResponseDTO.PlaceLikeDetailDTO placeLikeDetailDTO(PlaceLike placeLike) {
+    public static PlaceLikeResponseDTO.PlaceLikeDetailDTO placeLikeDetailDTO(PlaceLike placeLike, Place place) {
         return PlaceLikeResponseDTO.PlaceLikeDetailDTO.builder()
                 .placeLikeId(placeLike.getId())
-                .placeName(placeLike.getPlaceAnimation().getPlace().getName())
+                .placeName(place.getName())
                 .animationName(placeLike.getPlaceAnimation().getAnimation().getName())
-                .latitude(placeLike.getPlaceAnimation().getPlace().getLat())
-                .longitude(placeLike.getPlaceAnimation().getPlace().getLng())
+                .lat(place.getLat())
+                .lng(place.getLng())
                 .isFavorite(placeLike.getIsFavorite())
                 // 장소-애니메이션에 대한 해시태그
                 .hashtags(placeLike.getPlaceAnimation().getPlaceAnimationHashTags()

--- a/src/main/java/com/otakumap/domain/place_like/converter/PlaceLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/place_like/converter/PlaceLikeConverter.java
@@ -1,6 +1,7 @@
 package com.otakumap.domain.place_like.converter;
 
-import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.hash_tag.converter.HashTagConverter;
+import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place_like.dto.PlaceLikeResponseDTO;
 import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
@@ -11,11 +12,11 @@ public class PlaceLikeConverter {
     public static PlaceLikeResponseDTO.PlaceLikePreViewDTO placeLikePreViewDTO(PlaceLike placeLike) {
         return PlaceLikeResponseDTO.PlaceLikePreViewDTO.builder()
                 .id(placeLike.getId())
-                .placeId(placeLike.getPlace().getId())
-                .name(placeLike.getPlace().getName())
-                .detail(placeLike.getPlace().getDetail())
-                .lat(placeLike.getPlace().getLat())
-                .lng(placeLike.getPlace().getLng())
+                .placeId(placeLike.getPlaceAnimation().getPlace().getId())
+                .name(placeLike.getPlaceAnimation().getPlace().getName())
+                .detail(placeLike.getPlaceAnimation().getPlace().getDetail())
+                .lat(placeLike.getPlaceAnimation().getPlace().getLat())
+                .lng(placeLike.getPlaceAnimation().getPlace().getLng())
                 .isFavorite(placeLike.getIsFavorite())
                 .build();
 
@@ -29,10 +30,10 @@ public class PlaceLikeConverter {
                 .build();
     }
 
-    public static PlaceLike toPlaceLike(User user, Place place) {
+    public static PlaceLike toPlaceLike(User user, PlaceAnimation placeAnimation) {
         return PlaceLike.builder()
                 .user(user)
-                .place(place)
+                .placeAnimation(placeAnimation)
                 .isFavorite(false)
                 .build();
     }
@@ -41,6 +42,21 @@ public class PlaceLikeConverter {
         return PlaceLikeResponseDTO.FavoriteResultDTO.builder()
                 .placeLikeId(placeLike.getId())
                 .isFavorite(placeLike.getIsFavorite())
+                .build();
+    }
+
+    public static PlaceLikeResponseDTO.PlaceLikeDetailDTO placeLikeDetailDTO(PlaceLike placeLike) {
+        return PlaceLikeResponseDTO.PlaceLikeDetailDTO.builder()
+                .placeLikeId(placeLike.getId())
+                .placeName(placeLike.getPlaceAnimation().getPlace().getName())
+                .animationName(placeLike.getPlaceAnimation().getAnimation().getName())
+                .latitude(placeLike.getPlaceAnimation().getPlace().getLat())
+                .longitude(placeLike.getPlaceAnimation().getPlace().getLng())
+                .isFavorite(placeLike.getIsFavorite())
+                // 장소-애니메이션에 대한 해시태그
+                .hashtags(placeLike.getPlaceAnimation().getPlaceAnimationHashTags()
+                        .stream()
+                        .map(placeHashTag -> HashTagConverter.toHashTagDTO(placeHashTag.getHashTag())).toList())
                 .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/place_like/dto/PlaceLikeRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/place_like/dto/PlaceLikeRequestDTO.java
@@ -1,5 +1,6 @@
 package com.otakumap.domain.place_like.dto;
 
+import com.otakumap.global.validation.annotation.ExistAnimation;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -12,7 +13,7 @@ public class PlaceLikeRequestDTO {
 
     @Getter
     public static class SavePlaceLikeDTO {
-        @NotNull(message = "애니메이션 ID 입력은 필수입니다.")
+        @ExistAnimation
         Long animationId;
     }
 }

--- a/src/main/java/com/otakumap/domain/place_like/dto/PlaceLikeRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/place_like/dto/PlaceLikeRequestDTO.java
@@ -9,4 +9,10 @@ public class PlaceLikeRequestDTO {
         @NotNull(message = "즐겨찾기 여부 입력은 필수입니다.")
         Boolean isFavorite;
     }
+
+    @Getter
+    public static class SavePlaceLikeDTO {
+        @NotNull(message = "애니메이션 ID 입력은 필수입니다.")
+        Long animationId;
+    }
 }

--- a/src/main/java/com/otakumap/domain/place_like/dto/PlaceLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place_like/dto/PlaceLikeResponseDTO.java
@@ -1,6 +1,6 @@
 package com.otakumap.domain.place_like.dto;
 
-import jakarta.validation.constraints.NotNull;
+import com.otakumap.domain.hash_tag.dto.HashTagResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,5 +40,19 @@ public class PlaceLikeResponseDTO {
     public static class FavoriteResultDTO {
         Long placeLikeId;
         Boolean isFavorite;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PlaceLikeDetailDTO {
+        Long placeLikeId;
+        String placeName;
+        String animationName;
+        Double latitude;
+        Double longitude;
+        Boolean isFavorite;
+        List<HashTagResponseDTO.HashTagDTO> hashtags;
     }
 }

--- a/src/main/java/com/otakumap/domain/place_like/dto/PlaceLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place_like/dto/PlaceLikeResponseDTO.java
@@ -50,8 +50,8 @@ public class PlaceLikeResponseDTO {
         Long placeLikeId;
         String placeName;
         String animationName;
-        Double latitude;
-        Double longitude;
+        Double lat;
+        Double lng;
         Boolean isFavorite;
         List<HashTagResponseDTO.HashTagDTO> hashtags;
     }

--- a/src/main/java/com/otakumap/domain/place_like/entity/PlaceLike.java
+++ b/src/main/java/com/otakumap/domain/place_like/entity/PlaceLike.java
@@ -1,8 +1,6 @@
 package com.otakumap.domain.place_like.entity;
 
-
-import com.otakumap.domain.event.entity.Event;
-import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -28,8 +26,8 @@ public class PlaceLike extends BaseEntity {
     private User user;
 
     @ManyToOne
-    @JoinColumn(name = "place_id", nullable = false)
-    private Place place;
+    @JoinColumn(name = "place_animation_id", nullable = false)
+    private PlaceAnimation placeAnimation;
 
     @Column(name = "is_favorite", nullable = false)
     @ColumnDefault("false")

--- a/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
@@ -1,23 +1,17 @@
 package com.otakumap.domain.place_like.repository;
 
-import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.net.ContentHandler;
 import java.time.LocalDateTime;
-import java.util.List;
 
 public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
-
     Page<PlaceLike> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
-
     Page<PlaceLike> findAllByUserIsOrderByCreatedAtDesc(User user, Pageable pageable);
-
     Page<PlaceLike> findAllByUserIsAndCreatedAtLessThanOrderByCreatedAtDesc(User user, LocalDateTime createdAt, Pageable pageable);
-
-    boolean existsByUserAndPlace(User user, Place place);
+    boolean existsByUserAndPlaceAnimation(User user, PlaceAnimation placeAnimation);
 }

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeCommandService.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeCommandService.java
@@ -10,8 +10,6 @@ import java.util.List;
 @Service
 public interface PlaceLikeCommandService {
     void deletePlaceLike(List<Long> placeIds);
-
-    void savePlaceLike(User user, Long placeId);
-
+    void savePlaceLike(User user, Long placeId, PlaceLikeRequestDTO.SavePlaceLikeDTO request);
     PlaceLike favoritePlaceLike(Long placeLikeId, PlaceLikeRequestDTO.FavoriteDTO request);
 }

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeCommandServiceImpl.java
@@ -1,7 +1,8 @@
 package com.otakumap.domain.place_like.service;
 
-import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place.repository.PlaceRepository;
+import com.otakumap.domain.place_animation.repository.PlaceAnimationRepository;
 import com.otakumap.domain.place_like.converter.PlaceLikeConverter;
 import com.otakumap.domain.place_like.dto.PlaceLikeRequestDTO;
 import com.otakumap.domain.place_like.entity.PlaceLike;
@@ -23,6 +24,7 @@ public class PlaceLikeCommandServiceImpl implements PlaceLikeCommandService {
     private final PlaceLikeRepository placeLikeRepository;
     private final EntityManager entityManager;
     private final PlaceRepository placeRepository;
+    private final PlaceAnimationRepository placeAnimationRepository;
 
     @Override
     public void deletePlaceLike(List<Long> placeIds) {
@@ -32,16 +34,12 @@ public class PlaceLikeCommandServiceImpl implements PlaceLikeCommandService {
     }
 
     @Override
-    public void savePlaceLike(User user, Long placeId) {
-        Place place = placeRepository.findById(placeId)
-                .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
-
-        if (placeLikeRepository.existsByUserAndPlace(user, place)) {
+    public void savePlaceLike(User user, Long placeId, PlaceLikeRequestDTO.SavePlaceLikeDTO request) {
+        PlaceAnimation placeAnimation = placeAnimationRepository.findByPlaceIdAndAnimationId(placeId, request.getAnimationId()).orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_ANIMATION_NOT_FOUND));
+        if (placeLikeRepository.existsByUserAndPlaceAnimation(user, placeAnimation)) {
             throw new PlaceHandler(ErrorStatus.PLACE_LIKE_ALREADY_EXISTS);
         }
-
-        PlaceLike placeLike = PlaceLikeConverter.toPlaceLike(user, place);
-        placeLikeRepository.save(placeLike);
+        placeLikeRepository.save(PlaceLikeConverter.toPlaceLike(user, placeAnimation));
     }
 
     @Override

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryService.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryService.java
@@ -1,11 +1,10 @@
 package com.otakumap.domain.place_like.service;
 
 import com.otakumap.domain.place_like.dto.PlaceLikeResponseDTO;
-import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
 
 public interface PlaceLikeQueryService {
     PlaceLikeResponseDTO.PlaceLikePreViewListDTO getPlaceLikeList(User user, Long lastId, int limit);
     boolean isPlaceLikeExist(Long id);
-    PlaceLike getPlaceLike(Long placeLikeId);
+    PlaceLikeResponseDTO.PlaceLikeDetailDTO getPlaceLike(Long placeLikeId);
 }

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryService.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryService.java
@@ -1,9 +1,11 @@
 package com.otakumap.domain.place_like.service;
 
 import com.otakumap.domain.place_like.dto.PlaceLikeResponseDTO;
+import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
 
 public interface PlaceLikeQueryService {
     PlaceLikeResponseDTO.PlaceLikePreViewListDTO getPlaceLikeList(User user, Long lastId, int limit);
     boolean isPlaceLikeExist(Long id);
+    PlaceLike getPlaceLike(Long placeLikeId);
 }

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryServiceImpl.java
@@ -5,9 +5,9 @@ import com.otakumap.domain.place_like.dto.PlaceLikeResponseDTO;
 import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.place_like.repository.PlaceLikeRepository;
 import com.otakumap.domain.user.entity.User;
-import com.otakumap.domain.user.repository.UserRepository;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
 import com.otakumap.global.apiPayload.exception.handler.EventHandler;
+import com.otakumap.global.apiPayload.exception.handler.PlaceHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class PlaceLikeQueryServiceImpl implements PlaceLikeQueryService {
     private final PlaceLikeRepository placeLikeRepository;
-    private final UserRepository userRepository;
 
     @Override
     public PlaceLikeResponseDTO.PlaceLikePreViewListDTO getPlaceLikeList(User user, Long lastId, int limit) {
@@ -65,5 +64,10 @@ public class PlaceLikeQueryServiceImpl implements PlaceLikeQueryService {
     @Override
     public boolean isPlaceLikeExist(Long id) {
         return placeLikeRepository.existsById(id);
+    }
+
+    @Override
+    public PlaceLike getPlaceLike(Long placeLikeId) {
+        return placeLikeRepository.findById(placeLikeId).orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_LIKE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryServiceImpl.java
@@ -40,10 +40,10 @@ public class PlaceLikeQueryServiceImpl implements PlaceLikeQueryService {
             PlaceLike placeLike = placeLikeRepository.findById(lastId).orElseThrow(() -> new EventHandler(ErrorStatus.PLACE_LIKE_NOT_FOUND));
             result = placeLikeRepository.findAllByUserIsAndCreatedAtLessThanOrderByCreatedAtDesc(user, placeLike.getCreatedAt(), pageable).getContent();
         }
-        return createPlaceLikePreviewListDTO(user, result, limit);
+        return createPlaceLikePreviewListDTO(result, limit);
     }
 
-    private PlaceLikeResponseDTO.PlaceLikePreViewListDTO createPlaceLikePreviewListDTO(User user, List<PlaceLike> placeLikes, int limit) {
+    private PlaceLikeResponseDTO.PlaceLikePreViewListDTO createPlaceLikePreviewListDTO(List<PlaceLike> placeLikes, int limit) {
         boolean hasNext = placeLikes.size() > limit;
         Long lastId = null;
 
@@ -54,7 +54,7 @@ public class PlaceLikeQueryServiceImpl implements PlaceLikeQueryService {
 
         List<PlaceLikeResponseDTO.PlaceLikePreViewDTO> list = placeLikes
                 .stream()
-                .map(PlaceLikeConverter::placeLikePreViewDTO)
+                .map(placeLike -> PlaceLikeConverter.placeLikePreViewDTO(placeLike, placeLike.getPlaceAnimation().getPlace()))
                 .collect(Collectors.toList());
 
         return PlaceLikeConverter.placeLikePreViewListDTO(list, hasNext, lastId);
@@ -67,7 +67,8 @@ public class PlaceLikeQueryServiceImpl implements PlaceLikeQueryService {
     }
 
     @Override
-    public PlaceLike getPlaceLike(Long placeLikeId) {
-        return placeLikeRepository.findById(placeLikeId).orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_LIKE_NOT_FOUND));
+    public PlaceLikeResponseDTO.PlaceLikeDetailDTO getPlaceLike(Long placeLikeId) {
+        PlaceLike placeLike = placeLikeRepository.findById(placeLikeId).orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_LIKE_NOT_FOUND));
+        return PlaceLikeConverter.placeLikeDetailDTO(placeLike, placeLike.getPlaceAnimation().getPlace());
     }
 }

--- a/src/main/java/com/otakumap/domain/place_review/converter/PlaceReviewConverter.java
+++ b/src/main/java/com/otakumap/domain/place_review/converter/PlaceReviewConverter.java
@@ -67,17 +67,18 @@ public class PlaceReviewConverter {
                                                                                            List<PlaceReviewResponseDTO.AnimationReviewGroupDTO> animationGroups,
                                                                                            Float avgRating) {
 
-        List<HashTagResponseDTO.HashTagDTO> hashTagDTOs = place.getPlaceHashTagList()
-                .stream()
-                .map(placeHashTag -> HashTagConverter.toHashTagDTO(placeHashTag.getHashTag()))
-                .toList();
+        // place_hashtag -> place_animation_hashtag 변경에 따라 일단 주석 처리
+        //List<HashTagResponseDTO.HashTagDTO> hashTagDTOs = place.getPlaceHashTagList()
+        //        .stream()
+        //        .map(placeHashTag -> HashTagConverter.toHashTagDTO(placeHashTag.getHashTag()))
+        //        .toList();
 
         return PlaceReviewResponseDTO.PlaceAnimationReviewDTO.builder()
                 .placeId(place.getId())
                 .placeName(place.getName())
                 .animationGroups(animationGroups)
                 .totalReviews(totalReviews)
-                .hashTags(hashTagDTOs)
+                //.hashTags(hashTagDTOs)
                 .avgRating(avgRating)
                 .build();
     }

--- a/src/main/java/com/otakumap/domain/place_review/dto/PlaceReviewResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place_review/dto/PlaceReviewResponseDTO.java
@@ -56,7 +56,8 @@ public class PlaceReviewResponseDTO {
         private String placeName;
         private Float avgRating;
         private long totalReviews;
-        private List<HashTagResponseDTO.HashTagDTO> hashTags;
+        // place_hashtag -> place_animation_hashtag 변경에 따라 일단 주석 처리
+        //private List<HashTagResponseDTO.HashTagDTO> hashTags;
         private List<AnimationReviewGroupDTO> animationGroups;
     }
 

--- a/src/main/java/com/otakumap/global/validation/annotation/ExistAnimation.java
+++ b/src/main/java/com/otakumap/global/validation/annotation/ExistAnimation.java
@@ -1,0 +1,17 @@
+package com.otakumap.global.validation.annotation;
+
+import com.otakumap.global.validation.validator.AnimationExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = AnimationExistValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistAnimation {
+    String message() default "유효하지 않은 애니메이션 ID 입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/otakumap/global/validation/annotation/ExistPlaceListLike.java
+++ b/src/main/java/com/otakumap/global/validation/annotation/ExistPlaceListLike.java
@@ -1,17 +1,17 @@
 package com.otakumap.global.validation.annotation;
 
-import com.otakumap.global.validation.validator.PlaceLikeExistValidator;
+import com.otakumap.global.validation.validator.PlaceListLikeExistValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 import java.lang.annotation.*;
 
 @Documented
-@Constraint(validatedBy = PlaceLikeExistValidator.class)
+@Constraint(validatedBy = PlaceListLikeExistValidator.class)
 @Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ExistPlaceLike {
-    String message() default "유효하지 않은 명소 ID 입니다.";
+public @interface ExistPlaceListLike {
+    String message() default "유효하지 않은 명소 ID가 포함되어 있습니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/otakumap/global/validation/validator/AnimationExistValidator.java
+++ b/src/main/java/com/otakumap/global/validation/validator/AnimationExistValidator.java
@@ -1,0 +1,31 @@
+package com.otakumap.global.validation.validator;
+
+import com.otakumap.domain.animation.service.AnimationQueryService;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.validation.annotation.ExistAnimation;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AnimationExistValidator implements ConstraintValidator<ExistAnimation, Long> {
+    private final AnimationQueryService animationQueryService;
+
+    @Override
+    public void initialize(ExistAnimation constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long animationId, ConstraintValidatorContext context) {
+        boolean isValid = animationQueryService.existsById(animationId);
+
+        if(!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.ANIMATION_NOT_FOUND.toString()).addConstraintViolation();
+        }
+        return isValid;
+    }
+}

--- a/src/main/java/com/otakumap/global/validation/validator/PlaceListLikeExistValidator.java
+++ b/src/main/java/com/otakumap/global/validation/validator/PlaceListLikeExistValidator.java
@@ -2,30 +2,32 @@ package com.otakumap.global.validation.validator;
 
 import com.otakumap.domain.place_like.service.PlaceLikeQueryService;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
-import com.otakumap.global.validation.annotation.ExistPlaceLike;
+import com.otakumap.global.validation.annotation.ExistPlaceListLike;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class PlaceLikeExistValidator implements ConstraintValidator<ExistPlaceLike, Long> {
+public class PlaceListLikeExistValidator implements ConstraintValidator<ExistPlaceListLike, List<Long>> {
     private final PlaceLikeQueryService placeLikeQueryService;
 
     @Override
-    public void initialize(ExistPlaceLike constraintAnnotation) {
+    public void initialize(ExistPlaceListLike constraintAnnotation) {
         ConstraintValidator.super.initialize(constraintAnnotation);
     }
 
     @Override
-    public boolean isValid(Long placeLikeId, ConstraintValidatorContext context) {
-        if (placeLikeId == null ) {
+    public boolean isValid(List<Long> placeIds, ConstraintValidatorContext context) {
+        if (placeIds == null || placeIds.isEmpty()) {
             return false;
         }
 
-        boolean isValid = placeLikeQueryService.isPlaceLikeExist(placeLikeId);
+        boolean isValid = placeIds.stream()
+                .allMatch(placeId -> placeLikeQueryService.isPlaceLikeExist(placeId));
 
         if (!isValid) {
             context.disableDefaultConstraintViolation();


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #105 

## 📝 작업 내용
- 저장된 장소 상세 조회 API 구현, 장소 저장하기 API 수정했습니다.
- 명소 저장 시 선택한 애니메이션도 같이 저장되도록 변경됨에 따라, Place가 아닌 PlaceAnimation 테이블과 연관 관계를 맺도록 수정하였습니다. 또한, RequestBody에서 animationId를 받아 저장하는 방식으로 구현하였습니다. 
- 지도에서 장소 선택 시 보이는 해시태그가 같은 장소라도 애니메이션에 따라 다르게 부여되도록 변경됨에 따라, 기존의 place_hash_tag 테이블을 제거하고, place_animation과 hash_tag 테이블을 연결하는 새로운 매핑 테이블 place_animation_hash_tag를 생성하였습니다.
- 기존의 place_hash_tag를 사용하는 부분은 주석 처리해두었습니다.
![image](https://github.com/user-attachments/assets/3c3272ee-e517-4dce-aad2-710559cfe145)

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
