### PR TITLE
Feat: 저장된 루트 목록 조회 API 구현 (+즐겨찾기 목록)

### DIFF
--- a/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
@@ -3,7 +3,6 @@ package com.otakumap.domain.event_like.converter;
 import com.otakumap.domain.event.entity.Event;
 import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import com.otakumap.domain.event_like.entity.EventLike;
-import com.otakumap.domain.image.dto.ImageResponseDTO;
 import com.otakumap.domain.user.entity.User;
 
 import java.util.List;

--- a/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/event_like/converter/EventLikeConverter.java
@@ -20,7 +20,6 @@ public class EventLikeConverter {
                 .isFavorite(eventLike.getIsFavorite())
                 .eventType(eventLike.getEvent().getType())
                 .build();
-
     }
     public static EventLikeResponseDTO.EventLikePreViewListDTO eventLikePreViewListDTO(List<EventLikeResponseDTO.EventLikePreViewDTO> eventLikes, boolean hasNext, Long lastId) {
         return EventLikeResponseDTO.EventLikePreViewListDTO.builder()

--- a/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
+++ b/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
@@ -33,8 +33,8 @@ public class PlaceLikeController {
     @Operation(summary = "저장된 장소 목록 조회", description = "저장된 장소 목록을 불러옵니다.")
     @GetMapping("")
     @Parameters({
-            @Parameter(name = "lastId", description = "마지막으로 조회된 저장된 이벤트 id, 처음 가져올 때 -> 0"),
-            @Parameter(name = "limit", description = "한 번에 조회할 최대 이벤트 수. 기본값은 10입니다.")
+            @Parameter(name = "lastId", description = "마지막으로 조회된 저장된 장소 id, 처음 가져올 때 -> 0"),
+            @Parameter(name = "limit", description = "한 번에 조회할 최대 장소 수. 기본값은 10입니다.")
     })
     public ApiResponse<PlaceLikeResponseDTO.PlaceLikePreViewListDTO> getPlaceLikeList(@CurrentUser User user, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
         return ApiResponse.onSuccess(placeLikeQueryService.getPlaceLikeList(user, lastId, limit));

--- a/src/main/java/com/otakumap/domain/route_like/controller/RouteLikeController.java
+++ b/src/main/java/com/otakumap/domain/route_like/controller/RouteLikeController.java
@@ -6,6 +6,7 @@ import com.otakumap.domain.route_like.dto.RouteLikeRequestDTO;
 import com.otakumap.domain.route_like.dto.RouteLikeResponseDTO;
 import com.otakumap.domain.route_like.dto.UpdateNameRequestDTO;
 import com.otakumap.domain.route_like.service.RouteLikeCommandService;
+import com.otakumap.domain.route_like.service.RouteLikeQueryService;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.ApiResponse;
 import com.otakumap.global.validation.annotation.ExistRouteLike;
@@ -26,6 +27,7 @@ import java.util.List;
 public class RouteLikeController {
 
     private final RouteLikeCommandService routeLikeCommandService;
+    private final RouteLikeQueryService routeLikeQueryService;
 
     @Operation(summary = "루트 저장", description = "루트를 저장합니다.")
     @PostMapping("/{routeId}")
@@ -66,4 +68,16 @@ public class RouteLikeController {
     public ApiResponse<RouteLikeResponseDTO.RouteUpdateResultDTO> updateRouteLike(@RequestBody @Valid RouteLikeRequestDTO.UpdateRouteLikeDTO request, @CurrentUser User user) {
         return ApiResponse.onSuccess(RouteLikeConverter.toRouteUpdateResultDTO(routeLikeCommandService.updateRouteLike(request, user)));
     }
+
+    @Operation(summary = "저장된 루트 목록 조회(+ 즐겨찾기 목록 조회)", description = "저장된 루트 목록을 불러옵니다.")
+    @GetMapping("")
+    @Parameters({
+            @Parameter(name = "isFavorite", description = "즐겨찾기 여부(필수 X) -> true: 즐겨찾기 목록 조회"),
+            @Parameter(name = "lastId", description = "마지막으로 조회된 저장된 루트 id, 처음 가져올 때 -> 0"),
+            @Parameter(name = "limit", description = "한 번에 조회할 최대 루트 수. 기본값은 10입니다.")
+    })
+    public ApiResponse<RouteLikeResponseDTO.RouteLikePreViewListDTO> getRouteLikeList(@CurrentUser User user, @RequestParam(required = false) Boolean isFavorite, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
+        return ApiResponse.onSuccess(routeLikeQueryService.getRouteLikeList(user, isFavorite, lastId, limit));
+    }
+
 }

--- a/src/main/java/com/otakumap/domain/route_like/converter/RouteLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/route_like/converter/RouteLikeConverter.java
@@ -1,9 +1,12 @@
 package com.otakumap.domain.route_like.converter;
 
+import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import com.otakumap.domain.route.entity.Route;
 import com.otakumap.domain.route_like.dto.RouteLikeResponseDTO;
 import com.otakumap.domain.route_like.entity.RouteLike;
 import com.otakumap.domain.user.entity.User;
+
+import java.util.List;
 
 public class RouteLikeConverter {
     public static RouteLike toRouteLike(User user, Route route) {
@@ -33,6 +36,23 @@ public class RouteLikeConverter {
         return RouteLikeResponseDTO.RouteUpdateResultDTO.builder()
                 .routeId(routeLike.getRoute().getId())
                 .updatedAt(routeLike.getUpdatedAt())
+                .build();
+    }
+
+    public static RouteLikeResponseDTO.RouteLikePreViewDTO routeLikePreViewDTO(RouteLike routeLike) {
+        return RouteLikeResponseDTO.RouteLikePreViewDTO.builder()
+                .id(routeLike.getId())
+                .routeId(routeLike.getRoute().getId())
+                .name(routeLike.getRoute().getName())
+                .isFavorite(routeLike.getIsFavorite())
+                .build();
+    }
+
+    public static RouteLikeResponseDTO.RouteLikePreViewListDTO routeLikePreViewListDTO(List<RouteLikeResponseDTO.RouteLikePreViewDTO> routeLikes, boolean hasNext, Long lastId) {
+        return RouteLikeResponseDTO.RouteLikePreViewListDTO.builder()
+                .routeLikes(routeLikes)
+                .hasNext(hasNext)
+                .lastId(lastId)
                 .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/route_like/dto/RouteLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/route_like/dto/RouteLikeResponseDTO.java
@@ -1,11 +1,15 @@
 package com.otakumap.domain.route_like.dto;
 
+import com.otakumap.domain.event.entity.enums.EventType;
+import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class RouteLikeResponseDTO {
     @Builder
@@ -33,5 +37,26 @@ public class RouteLikeResponseDTO {
     public static class RouteUpdateResultDTO {
         Long routeId;
         LocalDateTime updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RouteLikePreViewDTO {
+        Long id; // RoutelikeId
+        Long routeId;
+        String name;
+        Boolean isFavorite;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RouteLikePreViewListDTO {
+        List<RouteLikeResponseDTO.RouteLikePreViewDTO> routeLikes;
+        boolean hasNext;
+        Long lastId;
     }
 }

--- a/src/main/java/com/otakumap/domain/route_like/service/RouteLikeQueryService.java
+++ b/src/main/java/com/otakumap/domain/route_like/service/RouteLikeQueryService.java
@@ -1,5 +1,9 @@
 package com.otakumap.domain.route_like.service;
 
+import com.otakumap.domain.route_like.dto.RouteLikeResponseDTO;
+import com.otakumap.domain.user.entity.User;
+
 public interface RouteLikeQueryService {
+    RouteLikeResponseDTO.RouteLikePreViewListDTO getRouteLikeList(User user, Boolean isFavorite, Long lastId, int limit);
     boolean isRouteLikeExist(Long id);
 }

--- a/src/main/java/com/otakumap/domain/route_like/service/RouteLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/route_like/service/RouteLikeQueryServiceImpl.java
@@ -30,6 +30,7 @@ public class RouteLikeQueryServiceImpl implements RouteLikeQueryService {
         QRouteLike qRouteLike = QRouteLike.routeLike;
         BooleanBuilder predicate = new BooleanBuilder();
 
+        //user가 좋아요(RouteLike)를 누른 데이터만 조회
         predicate.and(qRouteLike.user.eq(user));
 
         // isFavorite이 true일 때만 검색 조건에 추가
@@ -43,11 +44,11 @@ public class RouteLikeQueryServiceImpl implements RouteLikeQueryService {
 
         List<RouteLike> result = jpaQueryFactory
                 .selectFrom(qRouteLike)
-                .leftJoin(qRouteLike.route).fetchJoin()
-                .leftJoin(qRouteLike.user).fetchJoin()
-                .where(predicate)
-                .orderBy(qRouteLike.createdAt.desc())
-                .limit(limit + 1)
+                .leftJoin(qRouteLike.route).fetchJoin()  // Route 테이블 조인 (N:1)
+                .leftJoin(qRouteLike.user).fetchJoin()   // User 테이블 조인 (N:1)
+                .where(predicate)                        // 동적 필터링 적용
+                .orderBy(qRouteLike.createdAt.desc())    // 최신순 정렬
+                .limit(limit + 1)                        // limit보다 1개 더 조회 (hasNext 체크용)
                 .fetch();
 
         return createRouteLikePreviewListDTO(result, limit);

--- a/src/main/java/com/otakumap/domain/route_like/service/RouteLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/route_like/service/RouteLikeQueryServiceImpl.java
@@ -1,15 +1,72 @@
 package com.otakumap.domain.route_like.service;
 
+import com.otakumap.domain.event_like.converter.EventLikeConverter;
+import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
+import com.otakumap.domain.event_like.entity.EventLike;
+import com.otakumap.domain.route_like.converter.RouteLikeConverter;
+import com.otakumap.domain.route_like.dto.RouteLikeResponseDTO;
+import com.otakumap.domain.route_like.entity.QRouteLike;
+import com.otakumap.domain.route_like.entity.RouteLike;
 import com.otakumap.domain.route_like.repository.RouteLikeRepository;
+import com.otakumap.domain.user.entity.User;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RouteLikeQueryServiceImpl implements RouteLikeQueryService {
     private final RouteLikeRepository routeLikeRepository;
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public RouteLikeResponseDTO.RouteLikePreViewListDTO getRouteLikeList(User user, Boolean isFavorite, Long lastId, int limit) {
+        QRouteLike qRouteLike = QRouteLike.routeLike;
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        predicate.and(qRouteLike.user.eq(user));
+
+        // isFavorite이 true일 때만 검색 조건에 추가
+        if (isFavorite != null && isFavorite) {
+            predicate.and(qRouteLike .isFavorite.eq(isFavorite));
+        }
+
+        if (lastId != null && lastId > 0) {
+            predicate.and(qRouteLike.id.lt(lastId));
+        }
+
+        List<RouteLike> result = jpaQueryFactory
+                .selectFrom(qRouteLike)
+                .leftJoin(qRouteLike.route).fetchJoin()
+                .leftJoin(qRouteLike.user).fetchJoin()
+                .where(predicate)
+                .orderBy(qRouteLike.createdAt.desc())
+                .limit(limit + 1)
+                .fetch();
+
+        return createRouteLikePreviewListDTO(result, limit);
+    }
+
+    private RouteLikeResponseDTO.RouteLikePreViewListDTO createRouteLikePreviewListDTO(List<RouteLike> routeLikes, int limit) {
+        boolean hasNext = routeLikes.size() > limit;
+        Long lastId = null;
+        if (hasNext) {
+            routeLikes = routeLikes.subList(0, routeLikes.size() - 1);
+            lastId = routeLikes.get(routeLikes.size() - 1).getId();
+        }
+        List<RouteLikeResponseDTO.RouteLikePreViewDTO> list = routeLikes
+                .stream()
+                .map(RouteLikeConverter::routeLikePreViewDTO)
+                .collect(Collectors.toList());
+
+        return RouteLikeConverter.routeLikePreViewListDTO(list, hasNext, lastId);
+    }
 
     @Override
     public boolean isRouteLikeExist(Long id) {

--- a/src/main/java/com/otakumap/domain/route_like/service/RouteLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/route_like/service/RouteLikeQueryServiceImpl.java
@@ -1,8 +1,5 @@
 package com.otakumap.domain.route_like.service;
 
-import com.otakumap.domain.event_like.converter.EventLikeConverter;
-import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
-import com.otakumap.domain.event_like.entity.EventLike;
 import com.otakumap.domain.route_like.converter.RouteLikeConverter;
 import com.otakumap.domain.route_like.dto.RouteLikeResponseDTO;
 import com.otakumap.domain.route_like.entity.QRouteLike;


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #123 

## 📝 작업 내용
![image](https://github.com/user-attachments/assets/89c83d7f-f6b3-493e-b239-b23c5d968266)
- 전체 저장된 루트 목록 조회
- isFavorite: `false`
![image](https://github.com/user-attachments/assets/cc359aba-4407-4e51-bb10-f673fcd709bd)
- 즐겨찾기 true인 저장된 루트 목록만 조회
- isFavorite: `true`

## 💬 리뷰 요구사항
> RouteLikeQueryServiceImpl 파일에 QueryDSL을 적용한 조회 메소드를 구현했습니다. 주석이랑 코멘트로 설명 덧붙으니 확인해주시면 좋을 것 같습니다.