### PR TITLE
Feat: 저장된 장소 조회 구현(즐겨찾기 추가) + cors 에러 수정

### DIFF
--- a/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
+++ b/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
@@ -30,14 +30,15 @@ public class PlaceLikeController {
     private final PlaceLikeQueryService placeLikeQueryService;
     private final PlaceLikeCommandService placeLikeCommandService;
 
-    @Operation(summary = "저장된 장소 목록 조회", description = "저장된 장소 목록을 불러옵니다.")
+    @Operation(summary = "저장된 장소 목록 조회(+ 즐겨찾기 목록 조회)", description = "저장된 장소 목록을 불러옵니다.")
     @GetMapping("")
     @Parameters({
+            @Parameter(name = "isFavorite", description = "즐겨찾기 여부(필수 X) -> true: 즐겨찾기 목록 조회"),
             @Parameter(name = "lastId", description = "마지막으로 조회된 저장된 장소 id, 처음 가져올 때 -> 0"),
             @Parameter(name = "limit", description = "한 번에 조회할 최대 장소 수. 기본값은 10입니다.")
     })
-    public ApiResponse<PlaceLikeResponseDTO.PlaceLikePreViewListDTO> getPlaceLikeList(@CurrentUser User user, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
-        return ApiResponse.onSuccess(placeLikeQueryService.getPlaceLikeList(user, lastId, limit));
+    public ApiResponse<PlaceLikeResponseDTO.PlaceLikePreViewListDTO> getPlaceLikeList(@CurrentUser User user, @RequestParam(required = false) Boolean isFavorite, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
+        return ApiResponse.onSuccess(placeLikeQueryService.getPlaceLikeList(user, isFavorite, lastId, limit));
     }
 
     @Operation(summary = "저장된 장소 삭제", description = "저장된 장소를 삭제합니다.")

--- a/src/main/java/com/otakumap/domain/place_like/entity/PlaceLike.java
+++ b/src/main/java/com/otakumap/domain/place_like/entity/PlaceLike.java
@@ -1,6 +1,7 @@
 package com.otakumap.domain.place_like.entity;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
+import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -24,6 +25,10 @@ public class PlaceLike extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
 
     @ManyToOne
     @JoinColumn(name = "place_animation_id", nullable = false)

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryService.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryService.java
@@ -4,7 +4,7 @@ import com.otakumap.domain.place_like.dto.PlaceLikeResponseDTO;
 import com.otakumap.domain.user.entity.User;
 
 public interface PlaceLikeQueryService {
-    PlaceLikeResponseDTO.PlaceLikePreViewListDTO getPlaceLikeList(User user, Long lastId, int limit);
+    PlaceLikeResponseDTO.PlaceLikePreViewListDTO getPlaceLikeList(User user, Boolean isFavorite, Long lastId, int limit);
     boolean isPlaceLikeExist(Long id);
     PlaceLikeResponseDTO.PlaceLikeDetailDTO getPlaceLike(Long placeLikeId);
 }

--- a/src/main/java/com/otakumap/global/config/CorsConfig.java
+++ b/src/main/java/com/otakumap/global/config/CorsConfig.java
@@ -22,6 +22,7 @@ public class CorsConfig {
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
+        configuration.addExposedHeader("*");  // 모든 응답 헤더 노출
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #43
- 프론트 cors 에러 수정

## 📝 작업 내용
-   즐겨찾기 여부까지 추가해서 저장된 장소 조회 API 구현
- cors 에러
![image](https://github.com/user-attachments/assets/b64ed02d-e8df-40ae-af95-81a02dcea076)
get요청은 되는데, post 요청이 되지 않는 에러가 발생
`configuration.addExposedHeader("*");  // 모든 응답 헤더 노출` 해당 코드 추가

> **allowedHeader vs exposedHeader**
> - Allow는 preflight request에 대한 응답으로 어떤 헤더가 사용될 수 있는지 알려줌
> - Expose는 allowlist에 특정한 헤더들을 더해주어서 그 헤더들을 브라우저가 접근할 수 있게 해 줌

[참고한 블로그1](https://todayproject.tistory.com/entry/Spring-boot-CORS-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C%EC%9D%98-Response-Header-%EC%9D%B4%EC%8A%88)
[참고한 블로그2
](https://velog.io/@skyjoon34/CORS-CrossOrigin-exposedHeader-allowedHeader)
## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
