### PR TITLE
Fix: setAllowedOriginPatterns() 활용하여 CORS 에러 해결

### DIFF
--- a/src/main/java/com/otakumap/global/config/CorsConfig.java
+++ b/src/main/java/com/otakumap/global/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
     @Bean
     public static CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(
+        configuration.setAllowedOriginPatterns(Arrays.asList(
                 "http://localhost:3000",
                 "https://otakumap.netlify.app",
                 "https://deploy-preview-*--otakumap.netlify.app"  // 모든 프리뷰 URL 허용


### PR DESCRIPTION
## 🛰️ Issue Number
- Cors 에러

## 📝 작업 내용
- "https://deploy-preview-*--otakumap.netlify.app"의 * 와일드카드는 CORS 설정에서 사용할 수 없습니다.
- Spring의 setAllowedOrigins()는 특정한 도메인만 허용하며, 와일드카드를 포함한 동적 서브도메인을 허용하지 않습니다.

### **해결 방법**
setAllowedOriginPatterns() 사용 (Spring 5.3 이상)
- Spring 5.3 이상에서는 setAllowedOrigins() 대신 setAllowedOriginPatterns()를 사용하면 와일드카드를 포함한 도메인을 허용할 수 있습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
