### PR TITLE
Feat: 루트 내 특정 장소 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
@@ -34,9 +34,10 @@ public class PlaceResponseDTO {
     public static class PlaceDetailDTO {
         private Long id;
         private String name;
-        private Boolean isSelected;
         private Double latitude;
         private Double longitude;
+        private Boolean isFavorite;
+        private Boolean isLiked;
         private List<String> animeName;
         private List<String> hashtags;
     }

--- a/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
@@ -26,4 +26,18 @@ public class PlaceResponseDTO {
         private Long animationId;
         private String animationName;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PlaceDetailDTO {
+        private Long id;
+        private String name;
+        private Boolean isSelected;
+        private Double latitude;
+        private Double longitude;
+        private List<String> animeName;
+        private List<String> hashtags;
+    }
 }

--- a/src/main/java/com/otakumap/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/otakumap/domain/place/repository/PlaceRepository.java
@@ -2,10 +2,6 @@ package com.otakumap.domain.place.repository;
 
 import com.otakumap.domain.place.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
  }

--- a/src/main/java/com/otakumap/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/otakumap/domain/place/repository/PlaceRepository.java
@@ -2,6 +2,10 @@ package com.otakumap.domain.place.repository;
 
 import com.otakumap.domain.place.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-}
+ }

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryService.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryService.java
@@ -1,10 +1,12 @@
 package com.otakumap.domain.place.service;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
 
 import java.util.List;
 
 public interface PlaceQueryService {
     List<PlaceAnimation> getPlaceAnimations(Long placeId);
     boolean isPlaceExist(Long placeId);
+    PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(Long routeId, Long placeId);
 }

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryService.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryService.java
@@ -2,11 +2,12 @@ package com.otakumap.domain.place.service;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.user.entity.User;
 
 import java.util.List;
 
 public interface PlaceQueryService {
     List<PlaceAnimation> getPlaceAnimations(Long placeId);
     boolean isPlaceExist(Long placeId);
-    PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(Long routeId, Long placeId);
+    PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(User user, Long routeId, Long placeId);
 }

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
@@ -1,19 +1,26 @@
 package com.otakumap.domain.place.service;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.place_animation.repository.PlaceAnimationRepository;
+import com.otakumap.domain.route_item.repository.RouteItemRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.PlaceHandler;
 import jakarta.transaction.Transactional;
 import com.otakumap.domain.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PlaceQueryServiceImpl implements PlaceQueryService {
     private final PlaceRepository placeRepository;
     private final PlaceAnimationRepository placeAnimationRepository;
+    private final RouteItemRepository routeItemRepository;
 
     @Override
     public boolean isPlaceExist(Long placeId) {
@@ -24,5 +31,35 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     @Transactional
     public List<PlaceAnimation> getPlaceAnimations(Long placeId) {
         return placeAnimationRepository.findByPlaceId(placeId);
+    }
+
+    @Override
+    @Transactional
+    public PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(Long routeId, Long placeId) {
+        // RouteItem을 통해 Place 조회
+        Place place = routeItemRepository.findPlaceByRouteIdAndPlaceId(routeId, placeId)
+                .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
+
+        // 애니메이션 관련 정보 조회
+        List<PlaceAnimation> placeAnimations = placeAnimationRepository.findByPlaceId(placeId);
+        List<String> animeNames = placeAnimations.stream()
+                .map(placeAnimation -> placeAnimation.getAnimation().getName())
+                .collect(Collectors.toList());
+
+        // 해시태그 정보 조회
+        List<String> hashtags = placeAnimations.stream()
+                .flatMap(placeAnimation -> placeAnimation.getPlaceAnimationHashTags().stream())
+                .map(placeAnimationHashTag -> placeAnimationHashTag.getHashTag().getName())
+                .collect(Collectors.toList());
+
+        return PlaceResponseDTO.PlaceDetailDTO.builder()
+                .id(place.getId())
+                .name(place.getName())
+                .isSelected(Boolean.TRUE)  // isSelected는 True로 가정
+                .latitude(place.getLat())
+                .longitude(place.getLng())
+                .animeName(animeNames)
+                .hashtags(hashtags)
+                .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
@@ -5,10 +5,12 @@ import com.otakumap.domain.place.DTO.PlaceResponseDTO;
 import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.place_animation.repository.PlaceAnimationRepository;
 import com.otakumap.domain.place_like.repository.PlaceLikeRepository;
+import com.otakumap.domain.route.repository.RouteRepository;
 import com.otakumap.domain.route_item.repository.RouteItemRepository;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
 import com.otakumap.global.apiPayload.exception.handler.PlaceHandler;
+import com.otakumap.global.apiPayload.exception.handler.RouteHandler;
 import jakarta.transaction.Transactional;
 import com.otakumap.domain.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     private final PlaceAnimationRepository placeAnimationRepository;
     private final RouteItemRepository routeItemRepository;
     private final PlaceLikeRepository placeLikeRepository;
+    private final RouteRepository routeRepository;
 
     @Override
     public boolean isPlaceExist(Long placeId) {
@@ -39,6 +42,12 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     @Override
     @Transactional
     public PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(User user, Long routeId, Long placeId) {
+        // routeId가 존재하는지 먼저 확인
+        boolean routeExists = routeRepository.existsById(routeId);
+        if (!routeExists) {
+            throw new RouteHandler(ErrorStatus.ROUTE_NOT_FOUND);
+        }
+
         // RouteItem을 통해 Place 조회
         Place place = routeItemRepository.findPlaceByRouteIdAndPlaceId(routeId, placeId)
                 .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));

--- a/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
@@ -3,15 +3,12 @@ package com.otakumap.domain.place_like.repository;
 import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
-    Page<PlaceLike> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
-    Page<PlaceLike> findAllByUserIsOrderByCreatedAtDesc(User user, Pageable pageable);
-    Page<PlaceLike> findAllByUserIsAndCreatedAtLessThanOrderByCreatedAtDesc(User user, LocalDateTime createdAt, Pageable pageable);
     boolean existsByUserAndPlaceAnimation(User user, PlaceAnimation placeAnimation);
+    // 특정 Place와 연결된 PlaceLike가 존재하는지 확인
+    Optional<PlaceLike> findByPlaceIdAndUserId(Long placeId, Long userId);
 }

--- a/src/main/java/com/otakumap/domain/route/controller/RouteController.java
+++ b/src/main/java/com/otakumap/domain/route/controller/RouteController.java
@@ -29,9 +29,10 @@ public class RouteController {
             @Parameter(name = "placeId", description = "루트 내 특정 장소 ID")
     })
     public ApiResponse<PlaceResponseDTO.PlaceDetailDTO> getPlaceDetail(
+            @CurrentUser User user,
             @PathVariable Long routeId,
             @PathVariable Long placeId) {
-        PlaceResponseDTO.PlaceDetailDTO placeDetail = placeQueryService.getPlaceDetail(routeId, placeId);
+        PlaceResponseDTO.PlaceDetailDTO placeDetail = placeQueryService.getPlaceDetail(user, routeId, placeId);
         return ApiResponse.onSuccess(placeDetail);
     }
 }

--- a/src/main/java/com/otakumap/domain/route/controller/RouteController.java
+++ b/src/main/java/com/otakumap/domain/route/controller/RouteController.java
@@ -1,0 +1,37 @@
+package com.otakumap.domain.route.controller;
+
+import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.place.service.PlaceQueryService;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/route")
+@RequiredArgsConstructor
+@Validated
+public class RouteController {
+    private final PlaceQueryService placeQueryService;
+
+    @Operation(summary = "루트 내 특정 장소 상세 정보 조회", description = "주어진 routeId와 placeId를 기반으로 특정 장소의 상세 정보를 불러옵니다.")
+    @GetMapping("{routeId}/{placeId}")
+    @Parameters({
+            @Parameter(name = "routeId", description = "루트 ID"),
+            @Parameter(name = "placeId", description = "루트 내 특정 장소 ID")
+    })
+    public ApiResponse<PlaceResponseDTO.PlaceDetailDTO> getPlaceDetail(
+            @PathVariable Long routeId,
+            @PathVariable Long placeId) {
+        PlaceResponseDTO.PlaceDetailDTO placeDetail = placeQueryService.getPlaceDetail(routeId, placeId);
+        return ApiResponse.onSuccess(placeDetail);
+    }
+}

--- a/src/main/java/com/otakumap/domain/route_item/repository/RouteItemRepository.java
+++ b/src/main/java/com/otakumap/domain/route_item/repository/RouteItemRepository.java
@@ -1,0 +1,15 @@
+package com.otakumap.domain.route_item.repository;
+
+import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.route_item.entity.RouteItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface RouteItemRepository extends JpaRepository<RouteItem, Long> {
+
+    @Query("SELECT ri.place FROM RouteItem ri WHERE ri.route.id = :routeId AND ri.place.id = :placeId")
+    Optional<Place> findPlaceByRouteIdAndPlaceId(@Param("routeId") Long routeId, @Param("placeId") Long placeId);
+}

--- a/src/main/java/com/otakumap/domain/route_like/controller/RouteLikeController.java
+++ b/src/main/java/com/otakumap/domain/route_like/controller/RouteLikeController.java
@@ -4,7 +4,6 @@ import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
 import com.otakumap.domain.route_like.converter.RouteLikeConverter;
 import com.otakumap.domain.route_like.dto.RouteLikeRequestDTO;
 import com.otakumap.domain.route_like.dto.RouteLikeResponseDTO;
-import com.otakumap.domain.route_like.dto.UpdateNameRequestDTO;
 import com.otakumap.domain.route_like.service.RouteLikeCommandService;
 import com.otakumap.domain.route_like.service.RouteLikeQueryService;
 import com.otakumap.domain.user.entity.User;
@@ -79,5 +78,4 @@ public class RouteLikeController {
     public ApiResponse<RouteLikeResponseDTO.RouteLikePreViewListDTO> getRouteLikeList(@CurrentUser User user, @RequestParam(required = false) Boolean isFavorite, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
         return ApiResponse.onSuccess(routeLikeQueryService.getRouteLikeList(user, isFavorite, lastId, limit));
     }
-
 }

--- a/src/main/java/com/otakumap/domain/route_like/dto/RouteLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/route_like/dto/RouteLikeResponseDTO.java
@@ -1,13 +1,10 @@
 package com.otakumap.domain.route_like.dto;
 
-import com.otakumap.domain.event.entity.enums.EventType;
-import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #128 

## 📝 작업 내용
![image](https://github.com/user-attachments/assets/d8eba9dc-b89d-421f-9644-3a8da406c3da)
-   해당 화면을 위한 조회 api 
![image](https://github.com/user-attachments/assets/f5caf1a0-d4f2-44b0-8d72-b3521e9306a2)
- 루트ID와 장소ID 모두 존재해 잘 조회될 때
![image](https://github.com/user-attachments/assets/47ffd0dc-5d8f-425d-b603-f20337306fd8)
- 루트가 존재하지 않을 때, 예외처리
![image](https://github.com/user-attachments/assets/3640e88f-1f0d-46b9-a3cc-eaf3690382cf)
- 장소가 존재하지 않을 때, 예외처리

## 💬 리뷰 요구사항
> 현재 기능은 저장된(좋아요) 상태에 관계 없이 필요한 조회 기능이기 때문에 route controller에서 진행했습니다. 결국 장소를 조회하는 기능이기 때문에 placeQueryService를 사용했고 이 서비스 내에서는 route와 place가 모두 존재하는 지 확인하기 위해 routeItemRepository를 불러와 사용했습니다. 또한, 애니메이션과 해시태그 정보는 placeAnimationReposiotry를 통해 조회했습니다. 
- 해당 기능에 다른 패키지에 있는 클래스들을 많이 사용해서 이 사용이 적절한지 피드백해주시면 감사하겠습니다!
