### PR TITLE
Feat: 루트 상세 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
@@ -38,7 +38,7 @@ public class PlaceResponseDTO {
         private Double longitude;
         private Boolean isFavorite;
         private Boolean isLiked;
-        private List<String> animeName;
+        private PlaceResponseDTO.PlaceAnimationListDTO animationListDTO;
         private List<String> hashtags;
     }
 

--- a/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
@@ -34,9 +34,10 @@ public class PlaceResponseDTO {
     public static class PlaceDetailDTO {
         private Long id;
         private String name;
-        private Boolean isSelected;
         private Double latitude;
         private Double longitude;
+        private Boolean isFavorite;
+        private Boolean isLiked;
         private List<String> animeName;
         private List<String> hashtags;
     }

--- a/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
@@ -41,4 +41,15 @@ public class PlaceResponseDTO {
         private List<String> animeName;
         private List<String> hashtags;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PlaceDTO {
+        private Long id;
+        private String name;
+        private Double latitude;
+        private Double longitude;
+    }
 }

--- a/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place/DTO/PlaceResponseDTO.java
@@ -26,4 +26,18 @@ public class PlaceResponseDTO {
         private Long animationId;
         private String animationName;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PlaceDetailDTO {
+        private Long id;
+        private String name;
+        private Boolean isSelected;
+        private Double latitude;
+        private Double longitude;
+        private List<String> animeName;
+        private List<String> hashtags;
+    }
 }

--- a/src/main/java/com/otakumap/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/com/otakumap/domain/place/converter/PlaceConverter.java
@@ -1,8 +1,8 @@
 package com.otakumap.domain.place.converter;
 
-import com.otakumap.domain.animation.entity.Animation;
 import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.place.entity.Place;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -25,5 +25,40 @@ public class PlaceConverter {
                         .collect(Collectors.toList()))
                 .listSize(placeAnimations.size())
                 .build();
+    }
+
+    public static PlaceResponseDTO.PlaceDetailDTO toPlaceDetailDTO(Place place, PlaceResponseDTO.PlaceAnimationListDTO animationListDTO, List<String> hashtags, boolean isLiked) {
+        return PlaceResponseDTO.PlaceDetailDTO.builder()
+                .id(place.getId())
+                .name(place.getName())
+                .latitude(place.getLat())
+                .longitude(place.getLng())
+                .isFavorite(place.getIsFavorite())
+                .isLiked(isLiked)
+                .animationListDTO(animationListDTO)
+                .hashtags(hashtags)
+                .build();
+    }
+
+    public static List<String> toPlaceHashtagsDTO(List<PlaceAnimation> placeAnimations) {
+        return placeAnimations.stream()
+                .flatMap(placeAnimation -> placeAnimation.getPlaceAnimationHashTags().stream())
+                .map(placeAnimationHashTag -> placeAnimationHashTag.getHashTag().getName())
+                .collect(Collectors.toList());
+    }
+
+    public static PlaceResponseDTO.PlaceDTO toPlaceDTO(Place place) {
+        return new PlaceResponseDTO.PlaceDTO(
+                place.getId(),
+                place.getName(),
+                place.getLat(),
+                place.getLng()
+        );
+    }
+
+    public static List<PlaceResponseDTO.PlaceDTO> toPlaceDTOList(List<Place> places) {
+        return places.stream()
+                .map(PlaceConverter::toPlaceDTO)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/otakumap/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/otakumap/domain/place/repository/PlaceRepository.java
@@ -2,10 +2,6 @@ package com.otakumap.domain.place.repository;
 
 import com.otakumap.domain.place.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
  }

--- a/src/main/java/com/otakumap/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/otakumap/domain/place/repository/PlaceRepository.java
@@ -2,6 +2,10 @@ package com.otakumap.domain.place.repository;
 
 import com.otakumap.domain.place.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-}
+ }

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryService.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryService.java
@@ -1,10 +1,12 @@
 package com.otakumap.domain.place.service;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
 
 import java.util.List;
 
 public interface PlaceQueryService {
     List<PlaceAnimation> getPlaceAnimations(Long placeId);
     boolean isPlaceExist(Long placeId);
+    PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(Long routeId, Long placeId);
 }

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryService.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryService.java
@@ -2,11 +2,12 @@ package com.otakumap.domain.place.service;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.user.entity.User;
 
 import java.util.List;
 
 public interface PlaceQueryService {
     List<PlaceAnimation> getPlaceAnimations(Long placeId);
     boolean isPlaceExist(Long placeId);
-    PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(Long routeId, Long placeId);
+    PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(User user, Long routeId, Long placeId);
 }

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
@@ -1,19 +1,26 @@
 package com.otakumap.domain.place.service;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.place_animation.repository.PlaceAnimationRepository;
+import com.otakumap.domain.route_item.repository.RouteItemRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.PlaceHandler;
 import jakarta.transaction.Transactional;
 import com.otakumap.domain.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PlaceQueryServiceImpl implements PlaceQueryService {
     private final PlaceRepository placeRepository;
     private final PlaceAnimationRepository placeAnimationRepository;
+    private final RouteItemRepository routeItemRepository;
 
     @Override
     public boolean isPlaceExist(Long placeId) {
@@ -24,5 +31,35 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     @Transactional
     public List<PlaceAnimation> getPlaceAnimations(Long placeId) {
         return placeAnimationRepository.findByPlaceId(placeId);
+    }
+
+    @Override
+    @Transactional
+    public PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(Long routeId, Long placeId) {
+        // RouteItem을 통해 Place 조회
+        Place place = routeItemRepository.findPlaceByRouteIdAndPlaceId(routeId, placeId)
+                .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
+
+        // 애니메이션 관련 정보 조회
+        List<PlaceAnimation> placeAnimations = placeAnimationRepository.findByPlaceId(placeId);
+        List<String> animeNames = placeAnimations.stream()
+                .map(placeAnimation -> placeAnimation.getAnimation().getName())
+                .collect(Collectors.toList());
+
+        // 해시태그 정보 조회
+        List<String> hashtags = placeAnimations.stream()
+                .flatMap(placeAnimation -> placeAnimation.getPlaceAnimationHashTags().stream())
+                .map(placeAnimationHashTag -> placeAnimationHashTag.getHashTag().getName())
+                .collect(Collectors.toList());
+
+        return PlaceResponseDTO.PlaceDetailDTO.builder()
+                .id(place.getId())
+                .name(place.getName())
+                .isSelected(Boolean.TRUE)  // isSelected는 True로 가정
+                .latitude(place.getLat())
+                .longitude(place.getLng())
+                .animeName(animeNames)
+                .hashtags(hashtags)
+                .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
@@ -5,10 +5,12 @@ import com.otakumap.domain.place.DTO.PlaceResponseDTO;
 import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.place_animation.repository.PlaceAnimationRepository;
 import com.otakumap.domain.place_like.repository.PlaceLikeRepository;
+import com.otakumap.domain.route.repository.RouteRepository;
 import com.otakumap.domain.route_item.repository.RouteItemRepository;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
 import com.otakumap.global.apiPayload.exception.handler.PlaceHandler;
+import com.otakumap.global.apiPayload.exception.handler.RouteHandler;
 import jakarta.transaction.Transactional;
 import com.otakumap.domain.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     private final PlaceAnimationRepository placeAnimationRepository;
     private final RouteItemRepository routeItemRepository;
     private final PlaceLikeRepository placeLikeRepository;
+    private final RouteRepository routeRepository;
 
     @Override
     public boolean isPlaceExist(Long placeId) {
@@ -39,6 +42,12 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
     @Override
     @Transactional
     public PlaceResponseDTO.PlaceDetailDTO getPlaceDetail(User user, Long routeId, Long placeId) {
+        // routeId가 존재하는지 먼저 확인
+        boolean routeExists = routeRepository.existsById(routeId);
+        if (!routeExists) {
+            throw new RouteHandler(ErrorStatus.ROUTE_NOT_FOUND);
+        }
+
         // RouteItem을 통해 Place 조회
         Place place = routeItemRepository.findPlaceByRouteIdAndPlaceId(routeId, placeId)
                 .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));

--- a/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place/service/PlaceQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.otakumap.domain.place.service;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.place.converter.PlaceConverter;
 import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.place_animation.repository.PlaceAnimationRepository;
 import com.otakumap.domain.place_like.repository.PlaceLikeRepository;
@@ -17,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -54,29 +54,15 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
 
         // 애니메이션 관련 정보 조회
         List<PlaceAnimation> placeAnimations = placeAnimationRepository.findByPlaceId(placeId);
-        List<String> animeNames = placeAnimations.stream()
-                .map(placeAnimation -> placeAnimation.getAnimation().getName())
-                .collect(Collectors.toList());
+        PlaceResponseDTO.PlaceAnimationListDTO animationListDTO = PlaceConverter.toPlaceAnimationListDTO(placeAnimations);
 
         // 해시태그 정보 조회
-        List<String> hashtags = placeAnimations.stream()
-                .flatMap(placeAnimation -> placeAnimation.getPlaceAnimationHashTags().stream())
-                .map(placeAnimationHashTag -> placeAnimationHashTag.getHashTag().getName())
-                .collect(Collectors.toList());
+        List<String> hashtags = PlaceConverter.toPlaceHashtagsDTO(placeAnimations);
 
 
         // 특정 사용자가 해당 Place를 좋아요 했는지 여부 확인
         boolean isLiked = placeLikeRepository.findByPlaceIdAndUserId(placeId, user.getId()).isPresent();
 
-        return PlaceResponseDTO.PlaceDetailDTO.builder()
-                .id(place.getId())
-                .name(place.getName())
-                .latitude(place.getLat())
-                .longitude(place.getLng())
-                .isFavorite(place.getIsFavorite())
-                .isLiked(isLiked)
-                .animeName(animeNames)
-                .hashtags(hashtags)
-                .build();
+        return PlaceConverter.toPlaceDetailDTO(place, animationListDTO, hashtags, isLiked);
     }
 }

--- a/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
@@ -3,15 +3,12 @@ package com.otakumap.domain.place_like.repository;
 import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
-    Page<PlaceLike> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
-    Page<PlaceLike> findAllByUserIsOrderByCreatedAtDesc(User user, Pageable pageable);
-    Page<PlaceLike> findAllByUserIsAndCreatedAtLessThanOrderByCreatedAtDesc(User user, LocalDateTime createdAt, Pageable pageable);
     boolean existsByUserAndPlaceAnimation(User user, PlaceAnimation placeAnimation);
+    // 특정 Place와 연결된 PlaceLike가 존재하는지 확인
+    Optional<PlaceLike> findByPlaceIdAndUserId(Long placeId, Long userId);
 }

--- a/src/main/java/com/otakumap/domain/route/controller/RouteController.java
+++ b/src/main/java/com/otakumap/domain/route/controller/RouteController.java
@@ -29,9 +29,10 @@ public class RouteController {
             @Parameter(name = "placeId", description = "루트 내 특정 장소 ID")
     })
     public ApiResponse<PlaceResponseDTO.PlaceDetailDTO> getPlaceDetail(
+            @CurrentUser User user,
             @PathVariable Long routeId,
             @PathVariable Long placeId) {
-        PlaceResponseDTO.PlaceDetailDTO placeDetail = placeQueryService.getPlaceDetail(routeId, placeId);
+        PlaceResponseDTO.PlaceDetailDTO placeDetail = placeQueryService.getPlaceDetail(user, routeId, placeId);
         return ApiResponse.onSuccess(placeDetail);
     }
 }

--- a/src/main/java/com/otakumap/domain/route/controller/RouteController.java
+++ b/src/main/java/com/otakumap/domain/route/controller/RouteController.java
@@ -1,0 +1,37 @@
+package com.otakumap.domain.route.controller;
+
+import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.place.service.PlaceQueryService;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/route")
+@RequiredArgsConstructor
+@Validated
+public class RouteController {
+    private final PlaceQueryService placeQueryService;
+
+    @Operation(summary = "루트 내 특정 장소 상세 정보 조회", description = "주어진 routeId와 placeId를 기반으로 특정 장소의 상세 정보를 불러옵니다.")
+    @GetMapping("{routeId}/{placeId}")
+    @Parameters({
+            @Parameter(name = "routeId", description = "루트 ID"),
+            @Parameter(name = "placeId", description = "루트 내 특정 장소 ID")
+    })
+    public ApiResponse<PlaceResponseDTO.PlaceDetailDTO> getPlaceDetail(
+            @PathVariable Long routeId,
+            @PathVariable Long placeId) {
+        PlaceResponseDTO.PlaceDetailDTO placeDetail = placeQueryService.getPlaceDetail(routeId, placeId);
+        return ApiResponse.onSuccess(placeDetail);
+    }
+}

--- a/src/main/java/com/otakumap/domain/route/controller/RouteController.java
+++ b/src/main/java/com/otakumap/domain/route/controller/RouteController.java
@@ -3,6 +3,8 @@ package com.otakumap.domain.route.controller;
 import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
 import com.otakumap.domain.place.DTO.PlaceResponseDTO;
 import com.otakumap.domain.place.service.PlaceQueryService;
+import com.otakumap.domain.route.dto.RouteResponseDTO;
+import com.otakumap.domain.route.service.RouteQueryService;
 import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class RouteController {
     private final PlaceQueryService placeQueryService;
+    private final RouteQueryService routeQueryService;
 
     @Operation(summary = "루트 내 특정 장소 상세 정보 조회", description = "주어진 routeId와 placeId를 기반으로 특정 장소의 상세 정보를 불러옵니다.")
     @GetMapping("{routeId}/{placeId}")
@@ -34,5 +37,17 @@ public class RouteController {
             @PathVariable Long placeId) {
         PlaceResponseDTO.PlaceDetailDTO placeDetail = placeQueryService.getPlaceDetail(user, routeId, placeId);
         return ApiResponse.onSuccess(placeDetail);
+    }
+
+    @Operation(summary = "루트 상세 정보 조회", description = "주어진 routeId를 기반으로 루트의 상세 정보를 불러옵니다.")
+    @GetMapping("{routeId}")
+    @Parameters({
+            @Parameter(name = "routeId", description = "루트 ID")
+    })
+    public ApiResponse<RouteResponseDTO.RouteDetailDTO> getRouteDetail(
+            @CurrentUser User user,
+            @PathVariable Long routeId) {
+        RouteResponseDTO.RouteDetailDTO routeDetail = routeQueryService.getRouteDetail(user, routeId);
+        return ApiResponse.onSuccess(routeDetail);
     }
 }

--- a/src/main/java/com/otakumap/domain/route/dto/RouteResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/route/dto/RouteResponseDTO.java
@@ -1,5 +1,6 @@
 package com.otakumap.domain.route.dto;
 
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
 import com.otakumap.domain.route_item.dto.RouteItemResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,5 +18,14 @@ public class RouteResponseDTO {
     public static class RouteDTO {
         Long routeId;
         List<RouteItemResponseDTO.RouteItemDTO> routeItems;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RouteDetailDTO {
+        private Long routeId;
+        private List<PlaceResponseDTO.PlaceDTO> places;
     }
 }

--- a/src/main/java/com/otakumap/domain/route/service/RouteQueryService.java
+++ b/src/main/java/com/otakumap/domain/route/service/RouteQueryService.java
@@ -1,5 +1,9 @@
 package com.otakumap.domain.route.service;
 
+import com.otakumap.domain.route.dto.RouteResponseDTO;
+import com.otakumap.domain.user.entity.User;
+
 public interface RouteQueryService {
     boolean isRouteExist(Long routeId);
+    RouteResponseDTO.RouteDetailDTO getRouteDetail(User user, Long routeId);
 }

--- a/src/main/java/com/otakumap/domain/route/service/RouteQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/route/service/RouteQueryServiceImpl.java
@@ -1,16 +1,46 @@
 package com.otakumap.domain.route.service;
 
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.route.dto.RouteResponseDTO;
+import com.otakumap.domain.route.entity.Route;
 import com.otakumap.domain.route.repository.RouteRepository;
+import com.otakumap.domain.route_item.repository.RouteItemRepository;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.RouteHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RouteQueryServiceImpl implements RouteQueryService {
     private final RouteRepository routeRepository;
+    private final RouteItemRepository routeItemRepository;
 
     @Override
     public boolean isRouteExist(Long routeId) {
         return routeRepository.existsById(routeId);
+    }
+
+    @Override
+    public RouteResponseDTO.RouteDetailDTO getRouteDetail(User user, Long routeId) {
+        Route route = routeRepository.findById(routeId)
+                .orElseThrow(() -> new RouteHandler(ErrorStatus.ROUTE_NOT_FOUND));
+
+        // routeId로 Place 목록 조회
+        List<PlaceResponseDTO.PlaceDTO> places = routeItemRepository.findPlacesByRouteId(routeId)
+                .stream()
+                .map(place -> new PlaceResponseDTO.PlaceDTO(
+                        place.getId(),
+                        place.getName(),
+                        place.getLat(),
+                        place.getLng()
+                ))
+                .collect(Collectors.toList());
+
+        return new RouteResponseDTO.RouteDetailDTO(route.getId(), places);
     }
 }

--- a/src/main/java/com/otakumap/domain/route/service/RouteQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/route/service/RouteQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.otakumap.domain.route.service;
 
 import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.place.converter.PlaceConverter;
 import com.otakumap.domain.route.dto.RouteResponseDTO;
 import com.otakumap.domain.route.entity.Route;
 import com.otakumap.domain.route.repository.RouteRepository;
@@ -12,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,15 +31,7 @@ public class RouteQueryServiceImpl implements RouteQueryService {
                 .orElseThrow(() -> new RouteHandler(ErrorStatus.ROUTE_NOT_FOUND));
 
         // routeId로 Place 목록 조회
-        List<PlaceResponseDTO.PlaceDTO> places = routeItemRepository.findPlacesByRouteId(routeId)
-                .stream()
-                .map(place -> new PlaceResponseDTO.PlaceDTO(
-                        place.getId(),
-                        place.getName(),
-                        place.getLat(),
-                        place.getLng()
-                ))
-                .collect(Collectors.toList());
+        List<PlaceResponseDTO.PlaceDTO> places = PlaceConverter.toPlaceDTOList(routeItemRepository.findPlacesByRouteId(routeId));
 
         return new RouteResponseDTO.RouteDetailDTO(route.getId(), places);
     }

--- a/src/main/java/com/otakumap/domain/route_item/repository/RouteItemRepository.java
+++ b/src/main/java/com/otakumap/domain/route_item/repository/RouteItemRepository.java
@@ -1,0 +1,15 @@
+package com.otakumap.domain.route_item.repository;
+
+import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.route_item.entity.RouteItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface RouteItemRepository extends JpaRepository<RouteItem, Long> {
+
+    @Query("SELECT ri.place FROM RouteItem ri WHERE ri.route.id = :routeId AND ri.place.id = :placeId")
+    Optional<Place> findPlaceByRouteIdAndPlaceId(@Param("routeId") Long routeId, @Param("placeId") Long placeId);
+}

--- a/src/main/java/com/otakumap/domain/route_item/repository/RouteItemRepository.java
+++ b/src/main/java/com/otakumap/domain/route_item/repository/RouteItemRepository.java
@@ -6,10 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RouteItemRepository extends JpaRepository<RouteItem, Long> {
 
     @Query("SELECT ri.place FROM RouteItem ri WHERE ri.route.id = :routeId AND ri.place.id = :placeId")
     Optional<Place> findPlaceByRouteIdAndPlaceId(@Param("routeId") Long routeId, @Param("placeId") Long placeId);
+
+    @Query("SELECT ri.place FROM RouteItem ri WHERE ri.route.id = :routeId")
+    List<Place> findPlacesByRouteId(@Param("routeId") Long routeId);
 }

--- a/src/main/java/com/otakumap/domain/route_like/controller/RouteLikeController.java
+++ b/src/main/java/com/otakumap/domain/route_like/controller/RouteLikeController.java
@@ -4,7 +4,6 @@ import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
 import com.otakumap.domain.route_like.converter.RouteLikeConverter;
 import com.otakumap.domain.route_like.dto.RouteLikeRequestDTO;
 import com.otakumap.domain.route_like.dto.RouteLikeResponseDTO;
-import com.otakumap.domain.route_like.dto.UpdateNameRequestDTO;
 import com.otakumap.domain.route_like.service.RouteLikeCommandService;
 import com.otakumap.domain.route_like.service.RouteLikeQueryService;
 import com.otakumap.domain.user.entity.User;
@@ -79,5 +78,4 @@ public class RouteLikeController {
     public ApiResponse<RouteLikeResponseDTO.RouteLikePreViewListDTO> getRouteLikeList(@CurrentUser User user, @RequestParam(required = false) Boolean isFavorite, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
         return ApiResponse.onSuccess(routeLikeQueryService.getRouteLikeList(user, isFavorite, lastId, limit));
     }
-
 }

--- a/src/main/java/com/otakumap/domain/route_like/dto/RouteLikeResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/route_like/dto/RouteLikeResponseDTO.java
@@ -1,13 +1,10 @@
 package com.otakumap.domain.route_like.dto;
 
-import com.otakumap.domain.event.entity.enums.EventType;
-import com.otakumap.domain.event_like.dto.EventLikeResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #131 

## 📝 작업 내용
![image](https://github.com/user-attachments/assets/be6ef573-808b-4294-ad83-f43b9d1a6acb)
- 해당 화면을 위한 조회 api 구현
![image](https://github.com/user-attachments/assets/5e884781-69a9-4491-8bc2-49a42b301e6f)
- 파라미터로 받아온 routeId에 해당하는 place 내용을 list로 보여줌 (routeId가 존재하지 않을 시, 예외처리)
- routeId로 Place 목록 조회는 routeItemRepository를 통해 진행

## 💬 리뷰 요구사항
> [feat: 루트 상세 정보 조회 api 구현], [refactor: converter로 분리] 커밋만 확인해주시면 됩니다! 다른 커밋들은 [루트 내 특정 장소 상세 정보 조회]에서 진행된 커밋입니다!
