### PR TITLE
Feat: 명소 한줄 후기에 대한 좋아요/싫어요 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/place_short_review/entity/PlaceShortReview.java
+++ b/src/main/java/com/otakumap/domain/place_short_review/entity/PlaceShortReview.java
@@ -40,4 +40,8 @@ public class PlaceShortReview extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_animation_id")
     private PlaceAnimation placeAnimation;
+
+    public void updateLikes(Long likes) { this.likes = likes; }
+
+    public void updateDislikes(Long dislikes) { this.dislikes = dislikes; }
 }

--- a/src/main/java/com/otakumap/domain/user_reaction/DTO/UserReactionRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/user_reaction/DTO/UserReactionRequestDTO.java
@@ -1,0 +1,14 @@
+package com.otakumap.domain.user_reaction.DTO;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+
+public class UserReactionRequestDTO {
+    @Getter
+    public static class ReactionRequestDTO {
+        @Min(0)
+        @Max(1)
+        private int reactionType;
+    }
+}

--- a/src/main/java/com/otakumap/domain/user_reaction/DTO/UserReactionResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/user_reaction/DTO/UserReactionResponseDTO.java
@@ -1,0 +1,20 @@
+package com.otakumap.domain.user_reaction.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserReactionResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReactionResponseDTO {
+        private Long reviewId;
+        private Long likes;
+        private Long dislikes;
+        private Boolean isLiked;
+        private Boolean isDisliked;
+    }
+}

--- a/src/main/java/com/otakumap/domain/user_reaction/controller/UserReactionController.java
+++ b/src/main/java/com/otakumap/domain/user_reaction/controller/UserReactionController.java
@@ -1,0 +1,28 @@
+package com.otakumap.domain.user_reaction.controller;
+
+import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user_reaction.DTO.UserReactionResponseDTO;
+import com.otakumap.domain.user_reaction.converter.UserReactionConverter;
+import com.otakumap.domain.user_reaction.entity.UserReaction;
+import com.otakumap.domain.user_reaction.service.UserReactionCommandService;
+import com.otakumap.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserReactionController {
+    private final UserReactionCommandService userReactionCommandService;
+
+    @PostMapping("/places/{placeId}/short-reviews/{reviewId}/reaction")
+    @Operation(summary = "명소 한줄 리뷰에 좋아요/싫어요 남기기 및 취소하기", description = "0을 요청하면 dislike, 1을 요청하면 like이며, 이미 존재하는 반응을 요청하면 취소됩니다.")
+    public ApiResponse<UserReactionResponseDTO.ReactionResponseDTO> reactToReview(
+            @CurrentUser User user, @PathVariable Long placeId, @PathVariable Long reviewId, @Valid @RequestBody int reactionType) {
+        UserReaction userReaction = userReactionCommandService.reactToReview(user, reviewId, reactionType);
+        return ApiResponse.onSuccess(UserReactionConverter.toReactionResponseDTO(userReaction.getPlaceShortReview(), userReaction));
+    }
+}

--- a/src/main/java/com/otakumap/domain/user_reaction/converter/UserReactionConverter.java
+++ b/src/main/java/com/otakumap/domain/user_reaction/converter/UserReactionConverter.java
@@ -1,0 +1,34 @@
+package com.otakumap.domain.user_reaction.converter;
+
+import com.otakumap.domain.place_short_review.entity.PlaceShortReview;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user_reaction.DTO.UserReactionResponseDTO;
+import com.otakumap.domain.user_reaction.entity.UserReaction;
+
+public class UserReactionConverter {
+    public static UserReactionResponseDTO.ReactionResponseDTO toReactionResponseDTO(PlaceShortReview placeShortReview, UserReaction userReaction) {
+        return UserReactionResponseDTO.ReactionResponseDTO.builder()
+                .reviewId(placeShortReview.getId())
+                .likes(placeShortReview.getLikes())
+                .dislikes(placeShortReview.getDislikes())
+                .isLiked(userReaction.isLiked())
+                .isDisliked(userReaction.isDisliked())
+                .build();
+    }
+
+    public static UserReaction toLike(User user, PlaceShortReview placeShortReview, boolean isLiked) {
+        return UserReaction.builder()
+                .user(user)
+                .placeShortReview(placeShortReview)
+                .isLiked(isLiked)
+                .build();
+    }
+
+    public static UserReaction toDislike(User user, PlaceShortReview placeShortReview, boolean isDisliked) {
+        return UserReaction.builder()
+                .user(user)
+                .placeShortReview(placeShortReview)
+                .isDisliked(isDisliked)
+                .build();
+    }
+}

--- a/src/main/java/com/otakumap/domain/user_reaction/entity/UserReaction.java
+++ b/src/main/java/com/otakumap/domain/user_reaction/entity/UserReaction.java
@@ -1,0 +1,37 @@
+package com.otakumap.domain.user_reaction.entity;
+
+import com.otakumap.domain.place_short_review.entity.PlaceShortReview;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "user_reaction", uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "place_short_review_id"})})
+public class UserReaction extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_short_review_id", nullable = false)
+    private PlaceShortReview placeShortReview;
+
+    @Column(nullable = false)
+    private boolean isLiked;
+
+    @Column(nullable = false)
+    private boolean isDisliked;
+
+    public void updateLiked(boolean isLiked) { this.isLiked = isLiked; }
+
+    public void updateDisliked(boolean isDisliked) { this.isDisliked = isDisliked; }
+}

--- a/src/main/java/com/otakumap/domain/user_reaction/repository/UserReactionRepository.java
+++ b/src/main/java/com/otakumap/domain/user_reaction/repository/UserReactionRepository.java
@@ -1,0 +1,10 @@
+package com.otakumap.domain.user_reaction.repository;
+
+import com.otakumap.domain.user_reaction.entity.UserReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserReactionRepository extends JpaRepository<UserReaction, Long> {
+    Optional<UserReaction> findByUserIdAndPlaceShortReviewId(Long userId, Long placeShortReviewId);
+}

--- a/src/main/java/com/otakumap/domain/user_reaction/service/UserReactionCommandService.java
+++ b/src/main/java/com/otakumap/domain/user_reaction/service/UserReactionCommandService.java
@@ -1,0 +1,8 @@
+package com.otakumap.domain.user_reaction.service;
+
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user_reaction.entity.UserReaction;
+
+public interface UserReactionCommandService {
+    UserReaction reactToReview(User user, Long reviewId, int reactionType);
+}

--- a/src/main/java/com/otakumap/domain/user_reaction/service/UserReactionCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/user_reaction/service/UserReactionCommandServiceImpl.java
@@ -1,0 +1,58 @@
+package com.otakumap.domain.user_reaction.service;
+
+import com.otakumap.domain.place_short_review.entity.PlaceShortReview;
+import com.otakumap.domain.place_short_review.repository.PlaceShortReviewRepository;
+import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user_reaction.converter.UserReactionConverter;
+import com.otakumap.domain.user_reaction.entity.UserReaction;
+import com.otakumap.domain.user_reaction.repository.UserReactionRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.ReviewHandler;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserReactionCommandServiceImpl implements UserReactionCommandService {
+    private final UserReactionRepository userReactionRepository;
+    private final PlaceShortReviewRepository placeShortReviewRepository;
+
+    @Override
+    @Transactional
+    public UserReaction reactToReview(User user, Long reviewId, int reactionType) {
+        PlaceShortReview placeShortReview = placeShortReviewRepository.findById(reviewId).orElseThrow(() -> new ReviewHandler(ErrorStatus.PLACE_REVIEW_NOT_FOUND));
+
+        UserReaction userReaction = userReactionRepository.findByUserIdAndPlaceShortReviewId(user.getId(), reviewId).orElseGet(() -> null);
+
+        if (reactionType == 0) { // dislike
+            if (userReaction == null || (!userReaction.isLiked() && !userReaction.isDisliked())) { // 원래 아무 반응도 없었던 경우
+                userReaction = UserReactionConverter.toDislike(user, placeShortReview, true);
+                placeShortReview.updateDislikes(placeShortReview.getDislikes() + 1);
+            } else if (userReaction.isDisliked()) { // 원래 싫어요가 있었던 경우
+                userReaction.updateDisliked(false);
+                placeShortReview.updateDislikes(placeShortReview.getDislikes() - 1);
+            } else { // 원래 좋아요가 있었던 경우
+                userReaction.updateDisliked(true);
+                userReaction.updateLiked(false);
+                placeShortReview.updateDislikes(placeShortReview.getDislikes() + 1);
+                placeShortReview.updateLikes(placeShortReview.getLikes() - 1);
+            }
+        } else { // like
+            if (userReaction == null || (!userReaction.isLiked() && !userReaction.isDisliked())) {
+                userReaction = UserReactionConverter.toLike(user, placeShortReview, true);
+                placeShortReview.updateLikes(placeShortReview.getLikes() + 1);
+            } else if (userReaction.isLiked()) {
+                userReaction.updateLiked(false);
+                placeShortReview.updateLikes(placeShortReview.getLikes() - 1);
+            } else {
+                userReaction.updateLiked(true);
+                userReaction.updateDisliked(false);
+                placeShortReview.updateLikes(placeShortReview.getLikes() + 1);
+                placeShortReview.updateDislikes(placeShortReview.getDislikes() - 1);
+            }
+        }
+        placeShortReviewRepository.save(placeShortReview);
+        return userReactionRepository.save(userReaction);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #86 

## 📝 작업 내용
-   UserReaction 테이블 생성 (user_id, review_id, is_liked, is_disliked 컬럼 포함)
- 좋아요/싫어요 기능 구현 (reactionType: 0 -> 싫어요, 1 -> 좋아요)

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
핵심 로직: 좋아요/싫어요 상태 변경 로직 (특히, 중복 요청 및 좋아요/싫어요 간 전환 로직)
상세 로직:
이미 '좋아요' 상태에서 '좋아요' 요청 시: '좋아요' 취소 (상태: false)
이미 '싫어요' 상태에서 '좋아요' 요청 시: '싫어요' 취소 (false), '좋아요' 활성화 (true)
- 좋아요 요청
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/ebd66aa7-2dcc-4384-856f-9804d7d0f544" />
- 재요청시 취소
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/2aa2ec44-055d-478e-96d0-4d9266711ef5" />
