### PR TITLE
Feat: 이벤트/장소 검색 비회원 요청 허용

### DIFF
--- a/src/main/java/com/otakumap/domain/animation/converter/AnimationConverter.java
+++ b/src/main/java/com/otakumap/domain/animation/converter/AnimationConverter.java
@@ -8,12 +8,12 @@ import java.util.List;
 
 public class AnimationConverter {
 
-    public static AnimationResponseDTO.AnimationInfoDTO toAnimationInfoDTO(PlaceAnimation placeAnimation, Boolean isFavorite,
+    public static AnimationResponseDTO.AnimationInfoDTO toAnimationInfoDTO(PlaceAnimation placeAnimation, Boolean isLiked,
                                                                            List<HashTagResponseDTO.HashTagDTO> hashTags) {
         return AnimationResponseDTO.AnimationInfoDTO.builder()
                 .animationId(placeAnimation.getAnimation().getId())
                 .animationName(placeAnimation.getAnimation().getName())
-                .isFavorite(isFavorite)
+                .isLiked(isLiked)
                 .hashTags(hashTags)
                 .build();
     }

--- a/src/main/java/com/otakumap/domain/animation/dto/AnimationResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/animation/dto/AnimationResponseDTO.java
@@ -16,7 +16,7 @@ public class AnimationResponseDTO {
     public static class AnimationInfoDTO {
         private Long animationId;
         private String animationName;
-        private Boolean isFavorite;
+        private Boolean isLiked;
         private List<HashTagResponseDTO.HashTagDTO> hashTags;
     }
 }

--- a/src/main/java/com/otakumap/domain/auth/jwt/annotation/CurrentUser.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/annotation/CurrentUser.java
@@ -11,4 +11,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(hidden = true)
 public @interface CurrentUser {
+    boolean required() default true;
 }

--- a/src/main/java/com/otakumap/domain/auth/jwt/resolver/CurrentUserResolver.java
+++ b/src/main/java/com/otakumap/domain/auth/jwt/resolver/CurrentUserResolver.java
@@ -30,8 +30,14 @@ public class CurrentUserResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
+
         if (authentication != null) {
-            PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+            Object principal = authentication.getPrincipal();
+            // principal이 PrincipalDetails 타입이 아니면 (문자열 "anonymousUser"인 경우) null 반환
+            if (!(principal instanceof PrincipalDetails)) {
+                return null;
+            }
+            PrincipalDetails principalDetails = (PrincipalDetails) principal;
             return userQueryService.getUserByEmail(principalDetails.getUsername());
         }
         return null;

--- a/src/main/java/com/otakumap/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/otakumap/domain/event/converter/EventConverter.java
@@ -7,10 +7,6 @@ import com.otakumap.domain.hash_tag.dto.HashTagResponseDTO;
 import com.otakumap.domain.image.converter.ImageConverter;
 import org.springframework.data.domain.Page;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import java.util.List;
 
 public class EventConverter {
@@ -51,11 +47,11 @@ public class EventConverter {
                 .build();
     }
 
-    public static EventResponseDTO.SearchedEventInfoDTO toSearchedEventInfoDTO(Event event, Boolean isFavorite, String animationTitle, List<HashTagResponseDTO.HashTagDTO> hashTags) {
+    public static EventResponseDTO.SearchedEventInfoDTO toSearchedEventInfoDTO(Event event, Boolean isLiked, String animationTitle, List<HashTagResponseDTO.HashTagDTO> hashTags) {
         return EventResponseDTO.SearchedEventInfoDTO.builder()
                 .eventId(event.getId())
                 .name(event.getName())
-                .isLiked(isFavorite)
+                .isLiked(isLiked)
                 .animationTitle(animationTitle)
                 .hashTags(hashTags)
                 .build();

--- a/src/main/java/com/otakumap/domain/event_like/repository/EventLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/event_like/repository/EventLikeRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
-    EventLike findByUserAndEvent(User user, Event event);
+    Boolean existsByUserAndEvent(User user, Event event);
 }

--- a/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
@@ -11,6 +11,4 @@ public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
     boolean existsByUserAndPlaceAnimation(User user, PlaceAnimation placeAnimation);
     // 특정 Place와 연결된 PlaceLike가 존재하는지 확인
     Optional<PlaceLike> findByPlaceIdAndUserId(Long placeId, Long userId);
-
-    Optional<PlaceLike> findByUserAndPlaceAnimation(User user, PlaceAnimation placeAnimation);
 }

--- a/src/main/java/com/otakumap/domain/search/controller/SearchController.java
+++ b/src/main/java/com/otakumap/domain/search/controller/SearchController.java
@@ -32,7 +32,7 @@ public class SearchController {
     @Parameters({
             @Parameter(name = "keyword", description = "검색 키워드입니다."),
     })
-    public ApiResponse<List<SearchResponseDTO.SearchResultDTO>> getSearchedPlaceInfoList(@CurrentUser User user, @RequestParam String keyword) {
+    public ApiResponse<List<SearchResponseDTO.SearchResultDTO>> getSearchedPlaceInfoList(@CurrentUser(required=false) User user, @RequestParam String keyword) {
 
         return ApiResponse.onSuccess(searchService.getSearchedResult(user, keyword));
     }

--- a/src/main/java/com/otakumap/domain/search/service/SearchService.java
+++ b/src/main/java/com/otakumap/domain/search/service/SearchService.java
@@ -6,6 +6,5 @@ import com.otakumap.domain.user.entity.User;
 import java.util.List;
 
 public interface SearchService {
-
     List<SearchResponseDTO.SearchResultDTO> getSearchedResult (User user, String keyword);
 }

--- a/src/main/java/com/otakumap/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/search/service/SearchServiceImpl.java
@@ -23,9 +23,7 @@ import com.otakumap.domain.search.converter.SearchConverter;
 import com.otakumap.domain.search.dto.SearchResponseDTO;
 import com.otakumap.domain.search.repository.SearchRepositoryCustom;
 import com.otakumap.domain.user.entity.User;
-import com.otakumap.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +31,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SearchServiceImpl implements SearchService {
@@ -44,7 +41,6 @@ public class SearchServiceImpl implements SearchService {
     private final EventHashTagRepository eventHashTagRepository;
     private final PlaceLikeRepository placeLikeRepository;
     private final PlaceRepository placeRepository;
-    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     @Override

--- a/src/main/java/com/otakumap/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/search/service/SearchServiceImpl.java
@@ -6,7 +6,6 @@ import com.otakumap.domain.event.converter.EventConverter;
 import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.event.entity.Event;
 import com.otakumap.domain.event.entity.enums.EventStatus;
-import com.otakumap.domain.event_like.entity.EventLike;
 import com.otakumap.domain.event_like.repository.EventLikeRepository;
 import com.otakumap.domain.event_location.entity.EventLocation;
 import com.otakumap.domain.event_location.repository.EventLocationRepository;
@@ -108,8 +107,7 @@ public class SearchServiceImpl implements SearchService {
                     .stream().map(event -> {
                         boolean isLiked = false;
                         if(user != null) {
-                            EventLike eventLike = eventLikeRepository.findByUserAndEvent(user, event);
-                            isLiked = (eventLike != null);
+                            isLiked = eventLikeRepository.existsByUserAndEvent(user, event);
                         }
 
                         // 이벤트에 연결된 해시태그 조회

--- a/src/main/java/com/otakumap/global/config/SecurityConfig.java
+++ b/src/main/java/com/otakumap/global/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
     private final String[] allowGetUrl = {
             "/api/events/**",
             "/api/reviews/**",
+            "/api/map/**",
     };
 
     @Bean


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #138 

## 📝 작업 내용
-   지도에서 이벤트/장소 검색 기능을 비회원 요청도 처리할 수 있도록 변경했습니다.
- @CurrentUser에 required 속성을 추가했습니다.
- 비회원일 때는 User 객체가 null을 받도록 변경했습니다.

## 💬 리뷰 요구사항
>  기존 코드에서는, 비회원일 때 @CurrentUser로 User객체를 받으면 문자열 "anonymousUser"가 반환이 돼서 null이 반환되도록 변경했습니다.
