### PR TITLE
Fix: CORS 에러 해결을 위해 WebConfig에 배포된 프론트엔드 URL 추가

### DIFF
--- a/src/main/java/com/otakumap/global/config/WebConfig.java
+++ b/src/main/java/com/otakumap/global/config/WebConfig.java
@@ -25,7 +25,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "https://api.otakumap.site")
+                .allowedOrigins("http://localhost:3000", "https://otakumap.netlify.app", "https://deploy-preview-*--otakumap.netlify.app", "https://api.otakumap.site")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #83 

## 📝 작업 내용
- Spring Security 설정에서 인증되지 않은 사용자에 대한 CORS를 허용하기 위해 WebConfig에 배포된 프론트엔드 URL을 추가했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
