### PR TITLE
Feat: 이벤트 상세 조회 API의 이벤트 관련 애니 이름 가져오는 로직 수정

### DIFF
--- a/src/main/java/com/otakumap/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/otakumap/domain/event/converter/EventConverter.java
@@ -21,11 +21,11 @@ public class EventConverter {
                 .build();
     }
 
-    public static EventResponseDTO.EventDetailDTO toEventDetailDTO(Event event) {
+    public static EventResponseDTO.EventDetailDTO toEventDetailDTO(Event event, String animationName) {
         return EventResponseDTO.EventDetailDTO.builder()
                 .id(event.getId())
                 .title(event.getTitle())
-                .animationName(event.getAnimationName())
+                .animationName(animationName)
                 .name(event.getName())
                 .site(event.getSite())
                 .startDate(event.getStartDate())

--- a/src/main/java/com/otakumap/domain/event/entity/Event.java
+++ b/src/main/java/com/otakumap/domain/event/entity/Event.java
@@ -34,9 +34,6 @@ public class Event extends BaseEntity {
     @Column(nullable = false, length = 50) // 이벤트 일본어 원제
     private String name;
 
-    @Column(nullable = false, length = 50) // 이벤트에 해당하는 애니메이션 이름
-    private String animationName;
-
     @Column(nullable = false)
     private LocalDate startDate;
 

--- a/src/main/java/com/otakumap/domain/event/service/EventQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventQueryServiceImpl.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,7 +22,10 @@ public class EventQueryServiceImpl implements EventQueryService{
     @Override
     public EventResponseDTO.EventDetailDTO getEventDetail(Long eventId) {
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new EventHandler(ErrorStatus.EVENT_NOT_FOUND));
+        String animationName = event.getEventAnimationList().stream()
+                .map(ea -> ea.getAnimation().getName())
+                .collect(Collectors.joining(", "));
 
-        return EventConverter.toEventDetailDTO(event);
+        return EventConverter.toEventDetailDTO(event, animationName);
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #147 

## 📝 작업 내용
-  기존에는 Event 엔티티의 animationName 필드로 관련 애니 제목을 가져오는 로직이었으나, eventAnimationList로 가져오는 게 맞다고 생각하여 수정하였습니다!

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
