### PR TITLE
Fix: 저장된 장소 연관관계 수정

### DIFF
--- a/src/main/java/com/otakumap/domain/place_like/entity/PlaceLike.java
+++ b/src/main/java/com/otakumap/domain/place_like/entity/PlaceLike.java
@@ -26,10 +26,6 @@ public class PlaceLike extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "place_id", nullable = false)
-    private Place place;
-
     @ManyToOne
     @JoinColumn(name = "place_animation_id", nullable = false)
     private PlaceAnimation placeAnimation;

--- a/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
@@ -5,10 +5,6 @@ import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
     boolean existsByUserAndPlaceAnimation(User user, PlaceAnimation placeAnimation);
-    // 특정 Place와 연결된 PlaceLike가 존재하는지 확인
-    Optional<PlaceLike> findByPlaceIdAndUserId(Long placeId, Long userId);
 }

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeQueryServiceImpl.java
@@ -39,7 +39,7 @@ public class PlaceLikeQueryServiceImpl implements PlaceLikeQueryService {
 
         List<PlaceLike> result = jpaQueryFactory
                 .selectFrom(qPlaceLike)
-                .leftJoin(qPlaceLike.place).fetchJoin()
+                .leftJoin(qPlaceLike.placeAnimation).fetchJoin()
                 .leftJoin(qPlaceLike.user).fetchJoin()
                 .where(predicate)
                 .orderBy(qPlaceLike.createdAt.desc())


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #155 

## 📝 작업 내용
- 장소 저장 시 Place에 대한 애니 별로 저장 가능하기 때문에 PlaceLike와 Place와 연관관계를 가질 필요가 없습니다.
PlaceLike와 Place가 N:1로 되어 있어서 기존에 작업한 PlaceLike 관련 API에서 에러가 납니다.(이슈에서 확인 가능)
따라서 해당 설정을 제거하고 기존 코드를 수정하였습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
