### PR TITLE
Fix: 랜덤 로직 변경

### DIFF
--- a/src/main/java/com/otakumap/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/otakumap/domain/event/repository/EventRepositoryImpl.java
@@ -11,7 +11,6 @@ import com.otakumap.domain.image.dto.ImageResponseDTO;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
 import com.otakumap.global.apiPayload.exception.handler.EventHandler;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -61,18 +60,25 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
     public ImageResponseDTO.ImageDTO getEventBanner() {
         QEvent event = QEvent.event;
 
-        Event targetEvent = queryFactory.selectFrom(event)
+        List<Long> targetEventIds = queryFactory.select(event.id)
                 .where(event.endDate.goe(LocalDate.now())
                         .and(event.startDate.loe(LocalDate.now()))
                         .and(event.thumbnailImage.isNotNull()))
-                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
-                .fetchFirst();
+                .fetch();
 
-        if (targetEvent == null) {
+        Long targetEventId;
+        if(targetEventIds.isEmpty()) {
             return ImageResponseDTO.ImageDTO.builder()
-                    .fileUrl("default_banner_url")
-                    .build();
+                .fileUrl("default_banner_url")
+                .build();
+        } else if(targetEventIds.size() > 1) {
+            Collections.shuffle(targetEventIds);
         }
+        targetEventId = targetEventIds.get(0);
+
+        Event targetEvent = queryFactory.selectFrom(event)
+                .where(event.id.eq(targetEventId))
+                .fetchOne();
 
         return ImageConverter.toImageDTO((targetEvent)
                 .getThumbnailImage());

--- a/src/main/java/com/otakumap/domain/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/otakumap/domain/event/repository/EventRepositoryImpl.java
@@ -35,6 +35,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
         QEvent event = QEvent.event;
 
         List<Long> eventIds = queryFactory.select(event.id)
+                .from(event)
                 .where(event.endDate.goe(LocalDate.now())
                         .and(event.startDate.loe(LocalDate.now())))
                 .fetch();
@@ -61,6 +62,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
         QEvent event = QEvent.event;
 
         List<Long> targetEventIds = queryFactory.select(event.id)
+                .from(event)
                 .where(event.endDate.goe(LocalDate.now())
                         .and(event.startDate.loe(LocalDate.now()))
                         .and(event.thumbnailImage.isNotNull()))


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #122 

## 📝 작업 내용
- 데이터베이스에서 OrderBy로 랜덤 소팅을 진행하던 방법을 조건에 맞는 데이터의 아이디 추출, 애플리케이션 내에서 랜덤 소팅 이후 개수에 맞게 추출하여 리턴하는 방식으로 변경하였습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
데이터베이스 자체에서 랜덤으로 소팅하는 것은 쿼리 실행 시간을 오래 점유해 Connection pool error가 발생하는 것 같다는 의견을 보고 변경해보았습니다..! 데이터(event 객체)를 전부 가져오는 것보다 아이디만을 가져와서 shuffle을 통해 소팅하는 방식이 낫다고 판단해서 그렇게 진행했는데, 더 효율적인 다른 방법 등을 아시면 추천 부탁드립니다..!!