### PR TITLE
Feat: 저장한 이벤트 삭제 API 수정

### DIFF
--- a/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
+++ b/src/main/java/com/otakumap/domain/event_like/controller/EventLikeController.java
@@ -52,10 +52,10 @@ public class EventLikeController {
     @Operation(summary = "저장된 이벤트 삭제(이벤트 찜하기 취소)", description = "저장된 이벤트를 삭제합니다.")
     @DeleteMapping("")
     @Parameters({
-            @Parameter(name = "eventIds", description = "저장된 이벤트 ID List"),
+            @Parameter(name = "eventIds", description = "이벤트 ID List"),
     })
-    public ApiResponse<String> deleteEventLike(@RequestParam(required = false) @ExistEventLike List<Long> eventIds) {
-        eventLikeCommandService.deleteEventLike(eventIds);
+    public ApiResponse<String> deleteEventLike(@RequestParam(required = false) List<Long> eventIds, @CurrentUser User user) {
+        eventLikeCommandService.deleteEventLike(eventIds, user);
         return ApiResponse.onSuccess("저장된 이벤트가 성공적으로 삭제되었습니다");
     }
 

--- a/src/main/java/com/otakumap/domain/event_like/repository/EventLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/event_like/repository/EventLikeRepository.java
@@ -5,9 +5,9 @@ import com.otakumap.domain.event_like.entity.EventLike;
 import com.otakumap.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-;
-
+import java.util.Optional;
 
 public interface EventLikeRepository extends JpaRepository<EventLike, Long> {
     Boolean existsByUserAndEvent(User user, Event event);
+    Optional<EventLike> findByEventIdAndUserId(Long eventId, Long userId);
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandService.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandService.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface EventLikeCommandService {
     void addEventLike(User user, Long eventId);
-    void deleteEventLike(List<Long> eventIds);
+    void deleteEventLike(List<Long> eventIds, User user);
     EventLike favoriteEventLike(Long eventLikeId, EventLikeRequestDTO.FavoriteDTO request);
 }

--- a/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event_like/service/EventLikeCommandServiceImpl.java
@@ -31,8 +31,15 @@ public class EventLikeCommandServiceImpl implements EventLikeCommandService {
     }
 
     @Override
-    public void deleteEventLike(List<Long> eventIds) {
-        eventLikeRepository.deleteAllByIdInBatch(eventIds);
+    public void deleteEventLike(List<Long> eventIds, User user) {
+        List<Long> eventLikeIds = eventIds.stream()
+                .map(eventId -> eventLikeRepository.findByEventIdAndUserId(eventId, user.getId())
+                        .orElseThrow(() -> new EventHandler(ErrorStatus.EVENT_LIKE_NOT_FOUND))
+                        .getId()
+                )
+                .toList();
+
+        eventLikeRepository.deleteAllByIdInBatch(eventLikeIds);
         entityManager.flush();
         entityManager.clear();
     }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #176 

## 📝 작업 내용
- 저장한 이벤트 삭제 API에서 eventId로 삭제할 수 있도록 변경하였습니다(지도 창에서 하트를 누르면 저장한 이벤트 삭제 가능)

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
