### PR TITLE
Feat: 카카오 로그인 시 이름 대신 닉네임으로 가져오도록 임시 변경

### DIFF
--- a/src/main/java/com/otakumap/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/otakumap/domain/auth/dto/KakaoUserInfo.java
@@ -8,7 +8,13 @@ public class KakaoUserInfo {
 
     @Getter
     public static class KakaoAccount {
-        private String name;
+        //private String name;
+        private Profile profile;
         private String email;
+    }
+
+    @Getter
+    public static class Profile {
+        private String nickname;
     }
 }

--- a/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/otakumap/domain/user/converter/UserConverter.java
@@ -65,7 +65,7 @@ public class UserConverter {
 
     public static User toKakaoUser(KakaoUserInfo kakaoUserInfo) {
         return User.builder()
-                .name(kakaoUserInfo.getKakao_account().getName())
+                .name(kakaoUserInfo.getKakao_account().getProfile().getNickname())
                 .nickname(UuidGenerator.generateUuid())
                 .email(kakaoUserInfo.getKakao_account().getEmail())
                 .socialType(SocialType.KAKAO)


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #178 

## 📝 작업 내용
- 카카오 로그인 시 이름 대신 닉네임으로 가져오도록 임시 변경(자세한 건 이슈 참고)

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
