### PR TITLE
Feature: 저장된 장소 삭제 시, placeLikeId가 아닌 placeId로 조회해 삭제할 수 있게 수정

### DIFF
--- a/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
+++ b/src/main/java/com/otakumap/domain/place_like/controller/PlaceLikeController.java
@@ -11,7 +11,6 @@ import com.otakumap.global.apiPayload.ApiResponse;
 
 import com.otakumap.global.validation.annotation.ExistPlace;
 import com.otakumap.global.validation.annotation.ExistPlaceLike;
-import com.otakumap.global.validation.annotation.ExistPlaceListLike;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -44,10 +43,10 @@ public class PlaceLikeController {
     @Operation(summary = "저장된 장소 삭제", description = "저장된 장소를 삭제합니다.")
     @DeleteMapping("")
     @Parameters({
-            @Parameter(name = "placeIds", description = "저장된 장소 id List"),
+            @Parameter(name = "placeIds", description = "장소 id List"),
     })
-    public ApiResponse<String> deletePlaceLike(@RequestParam(required = false) @ExistPlaceListLike List<Long> placeIds) {
-        placeLikeCommandService.deletePlaceLike(placeIds);
+    public ApiResponse<String> deletePlaceLike(@RequestParam(required = false) List<Long> placeIds, @CurrentUser User user) {
+        placeLikeCommandService.deletePlaceLike(placeIds, user);
         return ApiResponse.onSuccess("저장된 장소가 성공적으로 삭제되었습니다");
     }
 

--- a/src/main/java/com/otakumap/domain/place_like/converter/PlaceLikeConverter.java
+++ b/src/main/java/com/otakumap/domain/place_like/converter/PlaceLikeConverter.java
@@ -31,9 +31,10 @@ public class PlaceLikeConverter {
                 .build();
     }
 
-    public static PlaceLike toPlaceLike(User user, PlaceAnimation placeAnimation) {
+    public static PlaceLike toPlaceLike(User user, Place place, PlaceAnimation placeAnimation) {
         return PlaceLike.builder()
                 .user(user)
+                .place(place)
                 .placeAnimation(placeAnimation)
                 .isFavorite(false)
                 .build();

--- a/src/main/java/com/otakumap/domain/place_like/entity/PlaceLike.java
+++ b/src/main/java/com/otakumap/domain/place_like/entity/PlaceLike.java
@@ -30,6 +30,10 @@ public class PlaceLike extends BaseEntity {
     @JoinColumn(name = "place_animation_id", nullable = false)
     private PlaceAnimation placeAnimation;
 
+    @ManyToOne
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
     @Column(name = "is_favorite", nullable = false)
     @ColumnDefault("false")
     private Boolean isFavorite;

--- a/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
+++ b/src/main/java/com/otakumap/domain/place_like/repository/PlaceLikeRepository.java
@@ -5,6 +5,9 @@ import com.otakumap.domain.place_like.entity.PlaceLike;
 import com.otakumap.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
     boolean existsByUserAndPlaceAnimation(User user, PlaceAnimation placeAnimation);
+    Optional<PlaceLike> findByPlaceIdAndUserId(Long placeId, Long userId);
 }

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeCommandService.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeCommandService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Service
 public interface PlaceLikeCommandService {
-    void deletePlaceLike(List<Long> placeIds);
+    void deletePlaceLike(List<Long> placeIds, User user);
     void savePlaceLike(User user, Long placeId, PlaceLikeRequestDTO.SavePlaceLikeDTO request);
     PlaceLike favoritePlaceLike(Long placeLikeId, PlaceLikeRequestDTO.FavoriteDTO request);
 }

--- a/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place_like/service/PlaceLikeCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package com.otakumap.domain.place_like.service;
 
 import com.otakumap.domain.mapping.PlaceAnimation;
+import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.place.repository.PlaceRepository;
 import com.otakumap.domain.place_animation.repository.PlaceAnimationRepository;
 import com.otakumap.domain.place_like.converter.PlaceLikeConverter;
@@ -23,12 +24,19 @@ import java.util.List;
 public class PlaceLikeCommandServiceImpl implements PlaceLikeCommandService {
     private final PlaceLikeRepository placeLikeRepository;
     private final EntityManager entityManager;
-    private final PlaceRepository placeRepository;
     private final PlaceAnimationRepository placeAnimationRepository;
+    private final PlaceRepository placeRepository;
 
     @Override
-    public void deletePlaceLike(List<Long> placeIds) {
-        placeLikeRepository.deleteAllByIdInBatch(placeIds);
+    public void deletePlaceLike(List<Long> placeIds, User user) {
+        List<Long> placeLikeIds = placeIds.stream()
+                .map(placeId -> placeLikeRepository.findByPlaceIdAndUserId(placeId, user.getId())
+                        .orElseThrow(()-> new PlaceHandler(ErrorStatus.PLACE_LIKE_NOT_FOUND))
+                        .getId()
+                )
+                .toList();
+
+        placeLikeRepository.deleteAllByIdInBatch(placeLikeIds);
         entityManager.flush();
         entityManager.clear();
     }
@@ -36,10 +44,15 @@ public class PlaceLikeCommandServiceImpl implements PlaceLikeCommandService {
     @Override
     public void savePlaceLike(User user, Long placeId, PlaceLikeRequestDTO.SavePlaceLikeDTO request) {
         PlaceAnimation placeAnimation = placeAnimationRepository.findByPlaceIdAndAnimationId(placeId, request.getAnimationId()).orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_ANIMATION_NOT_FOUND));
-        if (placeLikeRepository.existsByUserAndPlaceAnimation(user, placeAnimation)) {
+
+        // Place 존재 여부 확인
+        Place place = placeRepository.findById(placeId).orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
+
+        // 이미 PlaceLike가 존재하는지 확인
+        if (placeLikeRepository.existsByUserAndPlaceAnimation(user, placeAnimation))
             throw new PlaceHandler(ErrorStatus.PLACE_LIKE_ALREADY_EXISTS);
-        }
-        placeLikeRepository.save(PlaceLikeConverter.toPlaceLike(user, placeAnimation));
+
+        placeLikeRepository.save(PlaceLikeConverter.toPlaceLike(user, place, placeAnimation));
     }
 
     @Override


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #14 

## 📝 작업 내용
![image](https://github.com/user-attachments/assets/4e9f0d20-29fb-4d45-9ca5-5a8b190b5a26)

-  저장된 장소 삭제 시, placeLikeId가 아닌 placeId로 조회해 삭제할 수 있게 수정
- placeLike 엔티티에 place 매핑 추가

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
