### PR TITLE
Feat: 진행 중인 이벤트 API에 사용자 좋아요 여부 데이터 추가

### DIFF
--- a/src/main/java/com/otakumap/domain/event/controller/EventController.java
+++ b/src/main/java/com/otakumap/domain/event/controller/EventController.java
@@ -1,10 +1,12 @@
 package com.otakumap.domain.event.controller;
 
+import com.otakumap.domain.auth.jwt.annotation.CurrentUser;
 import com.otakumap.domain.event.converter.EventConverter;
 import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.event.service.EventCustomService;
 import com.otakumap.domain.event.service.EventQueryService;
 import com.otakumap.domain.image.dto.ImageResponseDTO;
+import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,8 +27,8 @@ public class EventController {
 
     @Operation(summary = "진행 중인 인기 이벤트 조회", description = "진행 중인 인기 이벤트의 목록(8개)를 불러옵니다.")
     @GetMapping("/events/popular")
-    public ApiResponse<List<EventResponseDTO.EventDTO>> getEventDetail() {
-        return ApiResponse.onSuccess(eventCustomService.getPopularEvents());
+    public ApiResponse<List<EventResponseDTO.EventWithLikeDTO>> getEventDetail(@CurrentUser User user) {
+        return ApiResponse.onSuccess(eventCustomService.getPopularEvents(user));
     }
 
     @Operation(summary = "이벤트 상세 정보 조회", description = "특정 이벤트의 상세 정보를 불러옵니다.")

--- a/src/main/java/com/otakumap/domain/event/converter/EventConverter.java
+++ b/src/main/java/com/otakumap/domain/event/converter/EventConverter.java
@@ -56,4 +56,16 @@ public class EventConverter {
                 .hashTags(hashTags)
                 .build();
     }
+
+    public static EventResponseDTO.EventWithLikeDTO toEventWithLikeDTO(Event event, Boolean isLiked) {
+        return EventResponseDTO.EventWithLikeDTO.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .isLiked(isLiked)
+                .startDate(event.getStartDate())
+                .endDate(event.getEndDate())
+                .thumbnail(ImageConverter.toImageDTO(event.getThumbnailImage()))
+                .build();
+
+    }
 }

--- a/src/main/java/com/otakumap/domain/event/dto/EventResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/event/dto/EventResponseDTO.java
@@ -28,6 +28,19 @@ public class EventResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class EventWithLikeDTO {
+        Long id;
+        String title;
+        Boolean isLiked;
+        LocalDate startDate;
+        LocalDate endDate;
+        ImageResponseDTO.ImageDTO thumbnail;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class EventDetailDTO {
         Long id;
         String title;

--- a/src/main/java/com/otakumap/domain/event/repository/EventRepositoryCustom.java
+++ b/src/main/java/com/otakumap/domain/event/repository/EventRepositoryCustom.java
@@ -2,12 +2,13 @@ package com.otakumap.domain.event.repository;
 
 import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.image.dto.ImageResponseDTO;
+import com.otakumap.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface EventRepositoryCustom {
-    List<EventResponseDTO.EventDTO> getPopularEvents();
+    List<EventResponseDTO.EventWithLikeDTO> getPopularEvents(User user);
     ImageResponseDTO.ImageDTO getEventBanner();
     Page<EventResponseDTO.EventDTO> getEventByGenre(String genre, Integer page, Integer size);
     Page<EventResponseDTO.EventDTO> getEventByStatusAndType(String status, String type, Integer page, Integer size);

--- a/src/main/java/com/otakumap/domain/event/service/EventCustomService.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventCustomService.java
@@ -2,12 +2,13 @@ package com.otakumap.domain.event.service;
 
 import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.image.dto.ImageResponseDTO;
+import com.otakumap.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface EventCustomService {
-    List<EventResponseDTO.EventDTO> getPopularEvents();
+    List<EventResponseDTO.EventWithLikeDTO> getPopularEvents(User user);
     ImageResponseDTO.ImageDTO getEventBanner();
     Page<EventResponseDTO.EventDTO> searchEventByCategory(String genre, String status, String type, Integer page, Integer size);
 }

--- a/src/main/java/com/otakumap/domain/event/service/EventCustomServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventCustomServiceImpl.java
@@ -3,6 +3,7 @@ package com.otakumap.domain.event.service;
 import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.event.repository.EventRepositoryCustom;
 import com.otakumap.domain.image.dto.ImageResponseDTO;
+import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
 import com.otakumap.global.apiPayload.exception.handler.EventHandler;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +19,8 @@ public class EventCustomServiceImpl implements EventCustomService {
     private final EventRepositoryCustom eventRepository;
 
     @Override
-    public List<EventResponseDTO.EventDTO> getPopularEvents() {
-        return eventRepository.getPopularEvents();
+    public List<EventResponseDTO.EventWithLikeDTO> getPopularEvents(User user) {
+        return eventRepository.getPopularEvents(user);
     }
 
     @Override


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #184 

## 📝 작업 내용
<img width="558" alt="Screenshot 2025-02-17 at 02 53 02" src="https://github.com/user-attachments/assets/631b9965-7928-4bc7-9e65-359acf497560" />
- 유저가 로그인 했을 경우 좋아요 여부를 진행 이벤트 API에 함께 반환하도록 구현
- connection pool 관련 에러 때문에 ... event banner, 진행 중인 이벤트 api 수정

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
테스트 결과
<img width="1475" alt="Screenshot 2025-02-17 at 02 44 53" src="https://github.com/user-attachments/assets/adf085dc-01fc-495e-a363-af82d8506551" />
