### PR TITLE
Feat: 해시태그 가져오는 로직 수정

### DIFF
--- a/src/main/java/com/otakumap/domain/event_location/repository/EventLocationRepository.java
+++ b/src/main/java/com/otakumap/domain/event_location/repository/EventLocationRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface EventLocationRepository extends JpaRepository<EventLocation, Long> {
+    List<EventLocation> findByLatAndLng(Double lat, Double lng);
 }

--- a/src/main/java/com/otakumap/domain/place_review/controller/PlaceReviewController.java
+++ b/src/main/java/com/otakumap/domain/place_review/controller/PlaceReviewController.java
@@ -1,35 +1,35 @@
-//package com.otakumap.domain.place_review.controller;
-//
-//import com.otakumap.domain.place_review.dto.PlaceReviewResponseDTO;
-//import com.otakumap.domain.place_review.service.PlaceReviewQueryService;
-//import com.otakumap.global.apiPayload.ApiResponse;
-//import io.swagger.v3.oas.annotations.Operation;
-//import io.swagger.v3.oas.annotations.Parameter;
-//import io.swagger.v3.oas.annotations.Parameters;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.web.bind.annotation.*;
-//
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/api")
-//public class PlaceReviewController {
-//    private final PlaceReviewQueryService placeReviewQueryService;
-//
-//    @GetMapping("/places/{placeId}/reviews")
-//    @Operation(summary = "특정 장소의 전체 후기 조회", description = "특정 장소의 후기들을 조회합니다")
-//    @Parameters({
-//            @Parameter(name = "placeId", description = "특정 장소의 id 입니다."),
-//            @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0"),
-//            @Parameter(name = "size", description = "한 페이지당 최대 리뷰 수", example = "10"),
-//            @Parameter(name = "sort", description = "정렬 기준 (latest 또는 views)", example = "latest")
-//    })
-//    public ApiResponse<PlaceReviewResponseDTO.PlaceAnimationReviewDTO> getPlaceReviewList(@PathVariable Long placeId,
-//                                                                                          @RequestParam(defaultValue = "0") int page,
-//                                                                                          @RequestParam(defaultValue = "10") int size,
-//                                                                                          @RequestParam(defaultValue = "latest") String sort) {
-//
-//        PlaceReviewResponseDTO.PlaceAnimationReviewDTO results = placeReviewQueryService.getReviewsByPlace(placeId, page, size, sort);
-//
-//        return ApiResponse.onSuccess(results);
-//    }
-//}
+package com.otakumap.domain.place_review.controller;
+
+import com.otakumap.domain.place_review.dto.PlaceReviewResponseDTO;
+import com.otakumap.domain.place_review.service.PlaceReviewQueryService;
+import com.otakumap.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class PlaceReviewController {
+    private final PlaceReviewQueryService placeReviewQueryService;
+
+    @GetMapping("/places/{placeId}/reviews")
+    @Operation(summary = "특정 장소의 전체 후기 조회", description = "특정 장소의 후기들을 조회합니다")
+    @Parameters({
+            @Parameter(name = "placeId", description = "특정 장소의 id 입니다."),
+            @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0"),
+            @Parameter(name = "size", description = "한 페이지당 최대 리뷰 수", example = "10"),
+            @Parameter(name = "sort", description = "정렬 기준 (latest 또는 views)", example = "latest")
+    })
+    public ApiResponse<PlaceReviewResponseDTO.PlaceAnimationReviewDTO> getPlaceReviewList(@PathVariable Long placeId,
+                                                                                          @RequestParam(defaultValue = "0") int page,
+                                                                                          @RequestParam(defaultValue = "10") int size,
+                                                                                          @RequestParam(defaultValue = "latest") String sort) {
+
+        PlaceReviewResponseDTO.PlaceAnimationReviewDTO results = placeReviewQueryService.getReviewsByPlace(placeId, page, size, sort);
+
+        return ApiResponse.onSuccess(results);
+    }
+}

--- a/src/main/java/com/otakumap/domain/place_review/converter/PlaceReviewConverter.java
+++ b/src/main/java/com/otakumap/domain/place_review/converter/PlaceReviewConverter.java
@@ -8,7 +8,6 @@ import com.otakumap.domain.place_review.dto.PlaceReviewResponseDTO;
 import com.otakumap.domain.place_review.entity.PlaceReview;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class PlaceReviewConverter {
     // PlaceReview -> PlaceReviewDTO 변환
@@ -16,7 +15,8 @@ public class PlaceReviewConverter {
 
         return PlaceReviewResponseDTO.PlaceReviewDTO.builder()
                 .reviewId(placeReview.getId())
-                .placeIds(placeReview.getPlaceList().stream().map(prp -> prp.getPlace().getId()).collect(Collectors.toList())) // 해령: placeId -> placeIds로 변경
+                .placeId(placeReview.getPlaceList().stream()
+                        .map(prp -> prp.getPlace().getId()).toList().get(0))
                 .title(placeReview.getTitle())
                 .content(placeReview.getContent())
                 .view(placeReview.getView())

--- a/src/main/java/com/otakumap/domain/place_review/dto/PlaceReviewResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/place_review/dto/PlaceReviewResponseDTO.java
@@ -17,7 +17,7 @@ public class PlaceReviewResponseDTO {
     @AllArgsConstructor
     public static class PlaceReviewDTO {
         private Long reviewId;
-        private List<Long> placeIds; // 해령: ids로 수정
+        private Long placeId;
         private String title;
         private String content;
         private Long view;

--- a/src/main/java/com/otakumap/domain/place_review/service/PlaceReviewQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/place_review/service/PlaceReviewQueryServiceImpl.java
@@ -1,111 +1,110 @@
-//package com.otakumap.domain.place_review.service;
-//
-//import com.otakumap.domain.animation.entity.Animation;
-//import com.otakumap.domain.hash_tag.converter.HashTagConverter;
-//import com.otakumap.domain.hash_tag.dto.HashTagResponseDTO;
-//import com.otakumap.domain.mapping.PlaceAnimation;
-//import com.otakumap.domain.mapping.PlaceReviewPlace;
-//import com.otakumap.domain.place.entity.Place;
-//import com.otakumap.domain.place.repository.PlaceRepository;
-//import com.otakumap.domain.place_review.converter.PlaceReviewConverter;
-//import com.otakumap.domain.place_review.dto.PlaceReviewResponseDTO;
-//import com.otakumap.domain.place_review.entity.PlaceReview;
-//import com.otakumap.domain.place_review.repository.PlaceReviewRepository;
-//import com.otakumap.domain.place_review_place.repository.PlaceReviewPlaceRepository;
-//import com.otakumap.domain.place_short_review.entity.PlaceShortReview;
-//import com.otakumap.domain.place_short_review.repository.PlaceShortReviewRepository;
-//import com.otakumap.global.apiPayload.code.status.ErrorStatus;
-//import com.otakumap.global.apiPayload.exception.handler.PlaceHandler;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.util.*;
-//import java.util.stream.Collectors;
-//
-//@Service
-//@RequiredArgsConstructor
-//@Transactional(readOnly = true)
-//public class PlaceReviewQueryServiceImpl implements PlaceReviewQueryService {
-//
-//    private final PlaceRepository placeRepository;
-//    private final PlaceReviewRepository placeReviewRepository;
-//    private final PlaceShortReviewRepository placeShortReviewRepository;
-//    private final PlaceReviewPlaceRepository placeReviewPlaceRepository;
-//
-//    @Override
-//    public PlaceReviewResponseDTO.PlaceAnimationReviewDTO getReviewsByPlace(Long placeId, int page, int size, String sort) {
-//
-//        Place place = placeRepository.findById(placeId)
-//                .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
-//
-//        // 전체 한 줄 리뷰 평균 별점 구하기
-//        List<PlaceShortReview> placeShortReviewList = placeShortReviewRepository.findAllByPlace(place);
-//        double avgRating = placeShortReviewList.stream()
-//                .mapToDouble(PlaceShortReview::getRating)
-//                .average()
-//                .orElse(0.0);
-//        Float finalAvgRating = (float)(Math.round(avgRating * 10) / 10.0);
-//
-//        // 전체 리뷰 리스트
-//        List<PlaceReviewPlace> placeReviewPlaces = placeReviewPlaceRepository.findByPlace(place);
-//        List<PlaceReview> allReviews = placeReviewPlaces.stream()
-//                .map(prp -> placeReviewRepository.findById(prp.getPlaceReview().getId()))
-//                .flatMap(Optional::stream)
-//                .toList();
-//
-//        // 애니메이션별 해시태그
-//        List<PlaceAnimation> placeAnimations = allReviews.stream()
-//                .map(PlaceReview::getPlaceAnimation)
-//                .filter(Objects::nonNull)
-//                .distinct()
-//                .toList();
-//        Map<Animation, List<HashTagResponseDTO.HashTagDTO>> animationHashTagMap =
-//                placeAnimations.stream()
-//                        .collect(Collectors.groupingBy(
-//                                PlaceAnimation::getAnimation, // 그룹의 키 : PlaceAnimation이 참조하는 Animation
-//
-//                                Collectors.flatMapping(
-//                                        pa -> pa.getPlaceAnimationHashTags().stream()
-//                                                .map(pah -> HashTagConverter.toHashTagDTO(pah.getHashTag())),
-//                                        Collectors.toList()
-//                                )
-//                        ));
-//
-//        // 애니메이션별로 리뷰 그룹화
-//        Map<Animation, List<PlaceReview>> reviewsByAnimation = allReviews.stream()
-//                .collect(Collectors.groupingBy(review -> review.getPlaceAnimation().getAnimation()));
-//
-//        // 애니메이션 그룹마다 그 안에 속한 리뷰들 페이징 적용
-//        List<PlaceReviewResponseDTO.AnimationReviewGroupDTO> animationGroups = paginateReviews(reviewsByAnimation, animationHashTagMap, page, size);
-//
-//        // 총 리뷰 수 계산
-//        long totalReviews = reviewsByAnimation.values().stream()
-//                .mapToLong(List::size)
-//                .sum();
-//
-//        return PlaceReviewConverter.toPlaceAnimationReviewDTO(place, totalReviews, animationGroups, finalAvgRating);
-//    }
-//
-//    private List<PlaceReviewResponseDTO.AnimationReviewGroupDTO> paginateReviews(Map<Animation, List<PlaceReview>> reviewsByAnimation,
-//                                                                                 Map<Animation, List<HashTagResponseDTO.HashTagDTO>> animationHashTagMap,
-//                                                                                 int page, int size) {
-//
-//        return  reviewsByAnimation.entrySet().stream()
-//                .map(entry -> {
-//                    Animation animation = entry.getKey();
-//                    List<PlaceReview> reviews = entry.getValue();
-//                    // 각 애니메이션에 해당하는 해시태그 목록을 가져오기
-//                    List<HashTagResponseDTO.HashTagDTO> hashTagsForAnimation = animationHashTagMap.getOrDefault(animation, Collections.emptyList());
-//
-//                    int fromIndex = Math.min(page * size, reviews.size());
-//                    int toIndex = Math.min(fromIndex + size, reviews.size());
-//
-//                    List<PlaceReview> pagedReviews = reviews.subList(fromIndex, toIndex);
-//
-//                    return PlaceReviewConverter.toAnimationReviewGroupDTO(animation, pagedReviews, hashTagsForAnimation);
-//                })
-//                .filter(group -> !group.getReviews().isEmpty()) // 빈 그룹 제외
-//                .toList();
-//    }
-//}
+package com.otakumap.domain.place_review.service;
+
+import com.otakumap.domain.animation.entity.Animation;
+import com.otakumap.domain.hash_tag.converter.HashTagConverter;
+import com.otakumap.domain.hash_tag.dto.HashTagResponseDTO;
+import com.otakumap.domain.mapping.PlaceReviewPlace;
+import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.place.repository.PlaceRepository;
+import com.otakumap.domain.place_review.converter.PlaceReviewConverter;
+import com.otakumap.domain.place_review.dto.PlaceReviewResponseDTO;
+import com.otakumap.domain.place_review.entity.PlaceReview;
+import com.otakumap.domain.place_review.repository.PlaceReviewRepository;
+import com.otakumap.domain.place_review_place.repository.PlaceReviewPlaceRepository;
+import com.otakumap.domain.place_short_review.entity.PlaceShortReview;
+import com.otakumap.domain.place_short_review.repository.PlaceShortReviewRepository;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.PlaceHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaceReviewQueryServiceImpl implements PlaceReviewQueryService {
+
+    private final PlaceRepository placeRepository;
+    private final PlaceReviewRepository placeReviewRepository;
+    private final PlaceShortReviewRepository placeShortReviewRepository;
+    private final PlaceReviewPlaceRepository placeReviewPlaceRepository;
+
+    @Override
+    public PlaceReviewResponseDTO.PlaceAnimationReviewDTO getReviewsByPlace(Long placeId, int page, int size, String sort) {
+
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
+
+        // 전체 한 줄 리뷰 평균 별점 구하기
+        List<PlaceShortReview> placeShortReviewList = placeShortReviewRepository.findAllByPlace(place);
+        double avgRating = placeShortReviewList.stream()
+                .mapToDouble(PlaceShortReview::getRating)
+                .average()
+                .orElse(0.0);
+        Float finalAvgRating = (float)(Math.round(avgRating * 10) / 10.0);
+
+        // 전체 리뷰 리스트
+        List<PlaceReviewPlace> placeReviewPlaces = placeReviewPlaceRepository.findByPlace(place);
+        List<PlaceReview> allReviews = placeReviewPlaces.stream()
+                .map(prp -> placeReviewRepository.findById(prp.getPlaceReview().getId()))
+                .flatMap(Optional::stream)
+                .distinct()
+                .toList();
+
+        // 애니메이션별 해시태그 (모든 리뷰에서 애니메이션 추출 -> 각 애니메이션에 연결된 hashtag 추출)
+        List<Animation> animations = allReviews.stream()
+                .map(PlaceReview::getAnimation)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        // 애니메이션별 해시태그 (각 애니메이션에 연결된 hashtag 추출)
+        Map<Animation, List<HashTagResponseDTO.HashTagDTO>> animationHashTagMap =
+                animations.stream()
+                        .collect(Collectors.toMap(
+                                animation -> animation,
+                                animation -> animation.getAnimationHashtags().stream()
+                                        .map(ah -> HashTagConverter.toHashTagDTO(ah.getHashTag()))
+                                        .collect(Collectors.toList())
+                        ));
+
+        // 애니메이션별로 리뷰 그룹화
+        Map<Animation, List<PlaceReview>> reviewsByAnimation = allReviews.stream()
+                .filter(review -> review.getAnimation() != null)
+                .collect(Collectors.groupingBy(PlaceReview::getAnimation));
+
+        // 애니메이션 그룹마다 그 안에 속한 리뷰들 페이징 적용
+        List<PlaceReviewResponseDTO.AnimationReviewGroupDTO> animationGroups = paginateReviews(reviewsByAnimation, animationHashTagMap, page, size);
+
+        // 총 리뷰 수 계산
+        long totalReviews = reviewsByAnimation.values().stream()
+                .mapToLong(List::size)
+                .sum();
+
+        return PlaceReviewConverter.toPlaceAnimationReviewDTO(place, totalReviews, animationGroups, finalAvgRating);
+    }
+
+    private List<PlaceReviewResponseDTO.AnimationReviewGroupDTO> paginateReviews(Map<Animation, List<PlaceReview>> reviewsByAnimation,
+                                                                                 Map<Animation, List<HashTagResponseDTO.HashTagDTO>> animationHashTagMap,
+                                                                                 int page, int size) {
+        return reviewsByAnimation.entrySet().stream()
+                .map(entry -> {
+                    Animation animation = entry.getKey();
+                    List<PlaceReview> reviews = entry.getValue();
+
+                    // 각 애니메이션에 해당하는 해시태그 목록을 가져오기
+                    List<HashTagResponseDTO.HashTagDTO> hashTagsForAnimation = animationHashTagMap.getOrDefault(animation, Collections.emptyList());
+
+                    int fromIndex = Math.min(page * size, reviews.size());
+                    int toIndex = Math.min(fromIndex + size, reviews.size());
+                    List<PlaceReview> pagedReviews = reviews.subList(fromIndex, toIndex);
+
+                    return PlaceReviewConverter.toAnimationReviewGroupDTO(animation, pagedReviews, hashTagsForAnimation);
+                })
+                .filter(group -> !group.getReviews().isEmpty()) // 빈 그룹 제외
+                .toList();
+    }
+
+}

--- a/src/main/java/com/otakumap/domain/search/controller/SearchController.java
+++ b/src/main/java/com/otakumap/domain/search/controller/SearchController.java
@@ -17,23 +17,23 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/api")
-//public class SearchController {
-//
-//    private final SearchService searchService;
-//
-//    @GetMapping("/map/search")
-//    @Operation(summary = "이벤트/작품명 지도 검색", description = "키워드로 이벤트/장소명/애니메이션 제목을 검색하여 관련된 장소 위치와 그 위치의 이벤트를 조회합니다.")
-//    @ApiResponses({
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-//    })
-//    @Parameters({
-//            @Parameter(name = "keyword", description = "검색 키워드입니다."),
-//    })
-//    public ApiResponse<List<SearchResponseDTO.SearchResultDTO>> getSearchedPlaceInfoList(@CurrentUser(required=false) User user, @RequestParam String keyword) {
-//
-//        return ApiResponse.onSuccess(searchService.getSearchedResult(user, keyword));
-//    }
-//}
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping("/map/search")
+    @Operation(summary = "이벤트/작품명 지도 검색", description = "키워드로 이벤트/장소명/애니메이션 제목을 검색하여 관련된 장소 위치와 그 위치의 이벤트를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "keyword", description = "검색 키워드입니다."),
+    })
+    public ApiResponse<List<SearchResponseDTO.SearchResultDTO>> getSearchedPlaceInfoList(@CurrentUser(required=false) User user, @RequestParam String keyword) {
+
+        return ApiResponse.onSuccess(searchService.getSearchedResult(user, keyword));
+    }
+}

--- a/src/main/java/com/otakumap/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/search/service/SearchServiceImpl.java
@@ -1,156 +1,156 @@
-//package com.otakumap.domain.search.service;
-//
-//import com.otakumap.domain.animation.converter.AnimationConverter;
-//import com.otakumap.domain.animation.dto.AnimationResponseDTO;
-//import com.otakumap.domain.event.converter.EventConverter;
-//import com.otakumap.domain.event.dto.EventResponseDTO;
-//import com.otakumap.domain.event.entity.Event;
-//import com.otakumap.domain.event.entity.enums.EventStatus;
-//import com.otakumap.domain.event_like.repository.EventLikeRepository;
-//import com.otakumap.domain.event_location.entity.EventLocation;
-//import com.otakumap.domain.event_location.repository.EventLocationRepository;
-//import com.otakumap.domain.hash_tag.converter.HashTagConverter;
-//import com.otakumap.domain.hash_tag.dto.HashTagResponseDTO;
-//import com.otakumap.domain.mapping.EventHashTag;
-//import com.otakumap.domain.mapping.repository.EventHashTagRepository;
-//import com.otakumap.domain.place.DTO.PlaceResponseDTO;
-//import com.otakumap.domain.place.converter.PlaceConverter;
-//import com.otakumap.domain.place.entity.Place;
-//import com.otakumap.domain.place.repository.PlaceRepository;
-//import com.otakumap.domain.place_like.repository.PlaceLikeRepository;
-//import com.otakumap.domain.search.converter.SearchConverter;
-//import com.otakumap.domain.search.dto.SearchResponseDTO;
-//import com.otakumap.domain.search.repository.SearchRepositoryCustom;
-//import com.otakumap.domain.user.entity.User;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.util.*;
-//import java.util.stream.Collectors;
-//import java.util.stream.Stream;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class SearchServiceImpl implements SearchService {
-//
-//    private final SearchRepositoryCustom searchRepository;
-//    private final EventLocationRepository eventLocationRepository;
-//    private final EventLikeRepository eventLikeRepository;
-//    private final EventHashTagRepository eventHashTagRepository;
-//    private final PlaceLikeRepository placeLikeRepository;
-//    private final PlaceRepository placeRepository;
-//
-//    @Transactional(readOnly = true)
-//    @Override
-//    public List<SearchResponseDTO.SearchResultDTO> getSearchedResult (User user, String keyword) {
-//
-//        List<Event> events = searchRepository.searchEventsByKeyword(keyword);
-//        List<Place> places = searchRepository.searchPlacesByKeyword(keyword);
-//
-//        List<Place> safePlaces = places != null ? places : Collections.emptyList(); // 불변
-//        List<Event> safeEvents = events != null ? events : new ArrayList<>(); // 가변
-//
-//        // 검색한 결과에 장소가 있을 때 -> 각 장소의 위/경도와 같은 곳에서 진행되고 있는 event를 찾음
-//        List<Event> newEvents = safePlaces.stream()
-//                .flatMap(place -> eventLocationRepository.findByLatAndLng(place.getLat(), place.getLng()).stream())
-//                .map(EventLocation::getEvent)
-//                .filter(event -> event != null && event.getStatus() != EventStatus.ENDED)
-//                .toList();
-//
-//        // 기존에 검색된 이벤트와 합치기
-//        List<Event> combinedEvents =
-//                Stream.concat(safeEvents.stream(), newEvents.stream())
-//                        .distinct() // 중복 이벤트 제거
-//                        .toList();
-//
-//        // 이벤트를 위치(위도, 경도) 기준으로 그룹화
-//        Map<String, List<Event>> groupedEvents = combinedEvents.stream()
-//                .filter(event -> event.getEventLocation() != null)
-//                .collect(Collectors.groupingBy(event ->
-//                        event.getEventLocation().getLat() + "," + event.getEventLocation().getLng()
-//                ));
-//
-//        // 장소들을 위치 기준으로 그룹화 (같은 위치에 여러 명소가 있을 수 있으므로 그룹화)
-//        Map<String, List<Place>> groupedPlaces = safePlaces.stream()
-//                .collect(Collectors.groupingBy(place -> place.getLat() + "," + place.getLng()));
-//
-//        // 만약 groupedEvents에는 존재하는 위치(key)가 groupedPlaces에 없다면,
-//        // 해당 위치의 장소들을 조회해서 groupedPlaces에 추가
-//        for (String key : groupedEvents.keySet()) {
-//            if (!groupedPlaces.containsKey(key)) {
-//                String[] parts = key.split(",");
-//                Double lat = Double.valueOf(parts[0]);
-//                Double lng = Double.valueOf(parts[1]);
-//
-//                List<Place> additionalPlaces = placeRepository.findByLatAndLng(lat, lng);
-//
-//                if (additionalPlaces != null && !additionalPlaces.isEmpty()) {
-//                    groupedPlaces.put(key, additionalPlaces);
-//                }
-//            }
-//        }
-//
-//        // 모든 위치 키의 합집합
-//        Set<String> allKeys = new HashSet<>();
-//        allKeys.addAll(groupedEvents.keySet());
-//        allKeys.addAll(groupedPlaces.keySet());
-//
-//        // 각 위치 키별로 이벤트와 장소 정보를 DTO로 변환하여 SearchResultDTO 생성
-//        return allKeys.stream().map(key -> {
-//            String[] parts = key.split(",");
-//            Double lat = Double.valueOf(parts[0]);
-//            Double lng = Double.valueOf(parts[1]);
-//
-//            // 해당 위치의 이벤트들을 DTO로 변환
-//            List<EventResponseDTO.SearchedEventInfoDTO> eventDTOs = groupedEvents.getOrDefault(key, Collections.emptyList())
-//                    .stream().map(event -> {
-//                        boolean isLiked = false;
-//                        if(user != null) {
-//                            isLiked = eventLikeRepository.existsByUserAndEvent(user, event);
-//                        }
-//
-//                        // 이벤트에 연결된 해시태그 조회
-//                        List<EventHashTag> eventHashTags = eventHashTagRepository.findByEvent(event);
-//                        List<HashTagResponseDTO.HashTagDTO> hashTags = eventHashTags.stream()
-//                                .map(eht -> HashTagConverter.toHashTagDTO(eht.getHashTag()))
-//                                .collect(Collectors.toList());
-//
-//                        // eventAnimationList를 이용해 애니메이션 제목을 추출 (여러 개가 있을 경우 콤마로 연결)
-//                        String animationTitle = event.getEventAnimationList().stream()
-//                                .map(ea -> ea.getAnimation().getName())
-//                                .collect(Collectors.joining(", "));
-//
-//                        return EventConverter.toSearchedEventInfoDTO(event, isLiked, animationTitle, hashTags);
-//                    })
-//                    .collect(Collectors.toList());
-//
-//            // 장소 DTO 변환
-//            List<PlaceResponseDTO.SearchedPlaceInfoDTO> placeDTOs = groupedPlaces.getOrDefault(key, Collections.emptyList())
-//                    .stream().map(place -> {
-//                        // 각 장소의 모든 PlaceAnimation을 AnimationInfoDTO 리스트로 변환 (애니메이션별 좋아요 여부 계산)
-//                        List<AnimationResponseDTO.AnimationInfoDTO> animationDTOs = place.getPlaceAnimationList().stream()
-//                                .map(placeAnimation -> {
-//                                    boolean isLiked = false;
-//                                    // 각 장소의 애니메이션별 좋아요 여부
-//                                    if (user != null) {
-//                                        isLiked = placeLikeRepository.existsByUserAndPlaceAnimation(user, placeAnimation);
-//                                    }
-//
-//                                    List<HashTagResponseDTO.HashTagDTO> hashTags = placeAnimation.getPlaceAnimationHashTags().stream()
-//                                            .map(pah -> HashTagConverter.toHashTagDTO(pah.getHashTag()))
-//                                            .collect(Collectors.toList());
-//
-//                                    return AnimationConverter.toAnimationInfoDTO(placeAnimation, isLiked, hashTags);
-//                                })
-//                                .collect(Collectors.toList());
-//
-//                        return PlaceConverter.toSearchedPlaceInfoDTO(place, animationDTOs);
-//                    })
-//                    .toList();
-//
-//            return SearchConverter.toSearchResultDTO(eventDTOs, placeDTOs, lat, lng);
-//        }).collect(Collectors.toList());
-//    }
-//
-//}
+package com.otakumap.domain.search.service;
+
+import com.otakumap.domain.animation.converter.AnimationConverter;
+import com.otakumap.domain.animation.dto.AnimationResponseDTO;
+import com.otakumap.domain.event.converter.EventConverter;
+import com.otakumap.domain.event.dto.EventResponseDTO;
+import com.otakumap.domain.event.entity.Event;
+import com.otakumap.domain.event.entity.enums.EventStatus;
+import com.otakumap.domain.event_like.repository.EventLikeRepository;
+import com.otakumap.domain.event_location.entity.EventLocation;
+import com.otakumap.domain.event_location.repository.EventLocationRepository;
+import com.otakumap.domain.hash_tag.converter.HashTagConverter;
+import com.otakumap.domain.hash_tag.dto.HashTagResponseDTO;
+import com.otakumap.domain.place.DTO.PlaceResponseDTO;
+import com.otakumap.domain.place.converter.PlaceConverter;
+import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.place.repository.PlaceRepository;
+import com.otakumap.domain.place_like.repository.PlaceLikeRepository;
+import com.otakumap.domain.search.converter.SearchConverter;
+import com.otakumap.domain.search.dto.SearchResponseDTO;
+import com.otakumap.domain.search.repository.SearchRepositoryCustom;
+import com.otakumap.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class SearchServiceImpl implements SearchService {
+
+    private final SearchRepositoryCustom searchRepository;
+    private final EventLocationRepository eventLocationRepository;
+    private final EventLikeRepository eventLikeRepository;
+    private final PlaceLikeRepository placeLikeRepository;
+    private final PlaceRepository placeRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<SearchResponseDTO.SearchResultDTO> getSearchedResult (User user, String keyword) {
+
+        List<Event> events = searchRepository.searchEventsByKeyword(keyword);
+        List<Place> places = searchRepository.searchPlacesByKeyword(keyword);
+
+        List<Place> safePlaces = places != null ? places : Collections.emptyList(); // 불변
+        List<Event> safeEvents = events != null ? events : new ArrayList<>(); // 가변
+
+        // 검색한 결과에 장소가 있을 때 -> 각 장소의 위/경도와 같은 곳에서 진행되고 있는 event를 찾음
+        List<Event> newEvents = safePlaces.stream()
+                .flatMap(place -> eventLocationRepository.findByLatAndLng(place.getLat(), place.getLng()).stream())
+                .map(EventLocation::getEvent)
+                .filter(event -> event != null && event.getStatus() != EventStatus.ENDED)
+                .toList();
+
+        // 기존에 검색된 이벤트와 합치기
+        List<Event> combinedEvents =
+                Stream.concat(safeEvents.stream(), newEvents.stream())
+                        .distinct() // 중복 이벤트 제거
+                        .toList();
+
+        // 이벤트를 위치(위도, 경도) 기준으로 그룹화
+        Map<String, List<Event>> groupedEvents = combinedEvents.stream()
+                .filter(event -> event.getEventLocation() != null)
+                .collect(Collectors.groupingBy(event ->
+                        event.getEventLocation().getLat() + "," + event.getEventLocation().getLng()
+                ));
+
+        // 장소들을 위치 기준으로 그룹화 (같은 위치에 여러 명소가 있을 수 있으므로 그룹화)
+        Map<String, List<Place>> groupedPlaces = safePlaces.stream()
+                .collect(Collectors.groupingBy(place -> place.getLat() + "," + place.getLng()));
+
+        // 만약 groupedEvents에는 존재하는 위치(key)가 groupedPlaces에 없다면,
+        // 해당 위치의 장소들을 조회해서 groupedPlaces에 추가
+        for (String key : groupedEvents.keySet()) {
+            if (!groupedPlaces.containsKey(key)) {
+                String[] parts = key.split(",");
+                Double lat = Double.valueOf(parts[0]);
+                Double lng = Double.valueOf(parts[1]);
+
+                List<Place> additionalPlaces = placeRepository.findByLatAndLng(lat, lng);
+
+                if (additionalPlaces != null && !additionalPlaces.isEmpty()) {
+                    groupedPlaces.put(key, additionalPlaces);
+                }
+            }
+        }
+
+        // 모든 위치 키의 합집합
+        Set<String> allKeys = new HashSet<>();
+        allKeys.addAll(groupedEvents.keySet());
+        allKeys.addAll(groupedPlaces.keySet());
+
+        // 각 위치 키별로 이벤트와 장소 정보를 DTO로 변환하여 SearchResultDTO 생성
+        return allKeys.stream().map(key -> {
+            String[] parts = key.split(",");
+            Double lat = Double.valueOf(parts[0]);
+            Double lng = Double.valueOf(parts[1]);
+
+            // 해당 위치의 이벤트들을 DTO로 변환
+            List<EventResponseDTO.SearchedEventInfoDTO> eventDTOs = groupedEvents.getOrDefault(key, Collections.emptyList())
+                    .stream().map(event -> {
+                        boolean isLiked = false;
+                        if(user != null) {
+                            isLiked = eventLikeRepository.existsByUserAndEvent(user, event);
+                        }
+
+                        // 이벤트에 연결된 해시태그 조회
+                        List<HashTagResponseDTO.HashTagDTO> eventHashTags = event.getEventAnimationList().stream()
+                                .flatMap(ea -> ea.getAnimation().getAnimationHashtags().stream())
+                                .map(ah -> HashTagConverter.toHashTagDTO(ah.getHashTag()))
+                                .distinct()
+                                .toList();
+
+                        // eventAnimationList를 이용해 애니메이션 제목을 추출 (여러 개가 있을 경우 콤마로 연결)
+                        String animationTitle = event.getEventAnimationList().stream()
+                                .map(ea -> ea.getAnimation().getName())
+                                .collect(Collectors.joining(", "));
+
+                        return EventConverter.toSearchedEventInfoDTO(event, isLiked, animationTitle, eventHashTags);
+                    })
+                    .collect(Collectors.toList());
+
+            // 장소 DTO 변환
+            List<PlaceResponseDTO.SearchedPlaceInfoDTO> placeDTOs = groupedPlaces.getOrDefault(key, Collections.emptyList())
+                    .stream().map(place -> {
+                        // 각 장소의 모든 PlaceAnimation을 AnimationInfoDTO 리스트로 변환 (애니메이션별 좋아요 여부 계산)
+                        List<AnimationResponseDTO.AnimationInfoDTO> animationDTOs = place.getPlaceAnimationList().stream()
+                                .map(placeAnimation -> {
+                                    boolean isLiked = false;
+                                    // 각 장소의 애니메이션별 좋아요 여부
+                                    if (user != null) {
+                                        isLiked = placeLikeRepository.existsByUserAndPlaceAnimation(user, placeAnimation);
+                                    }
+
+                                    List<HashTagResponseDTO.HashTagDTO> placeHashTags = place.getPlaceAnimationList().stream()
+                                            .flatMap(pa -> pa.getAnimation().getAnimationHashtags().stream())
+                                            .map(ah -> HashTagConverter.toHashTagDTO(ah.getHashTag()))
+                                            .distinct()
+                                            .toList();
+
+                                    return AnimationConverter.toAnimationInfoDTO(placeAnimation, isLiked, placeHashTags);
+                                })
+                                .collect(Collectors.toList());
+
+                        return PlaceConverter.toSearchedPlaceInfoDTO(place, animationDTOs);
+                    })
+                    .toList();
+
+            return SearchConverter.toSearchResultDTO(eventDTOs, placeDTOs, lat, lng);
+        }).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/otakumap/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/search/service/SearchServiceImpl.java
@@ -135,6 +135,7 @@ public class SearchServiceImpl implements SearchService {
                                         isLiked = placeLikeRepository.existsByUserAndPlaceAnimation(user, placeAnimation);
                                     }
 
+                                    // 해시태그 조회
                                     List<HashTagResponseDTO.HashTagDTO> placeHashTags = place.getPlaceAnimationList().stream()
                                             .flatMap(pa -> pa.getAnimation().getAnimationHashtags().stream())
                                             .map(ah -> HashTagConverter.toHashTagDTO(ah.getHashTag()))


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #185 

## 📝 작업 내용
-   특정 장소의 전체 후기 조회 기능에 장소의 해시태그를 가져오는 로직을 수정했습니다.
-  지도에서 이벤트/작품명 검색 기능에 각 이벤트와 장소의 해시태그를 가져오는 로직을 수정했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
해시태그 관련 주석 아래 코드만 보시면 됩니다! 해시태그 가져오는 로직만 바뀌었어요.
