### PR TITLE
Refactor: 지도에서 장소 및 이벤트 정보 보기 API 해시태그 관련 로직 수정 및 애니메이션 관련 데이터 추가

### DIFF
--- a/src/main/java/com/otakumap/domain/map/controller/MapController.java
+++ b/src/main/java/com/otakumap/domain/map/controller/MapController.java
@@ -13,27 +13,27 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-//@RestController
-//@RequestMapping("/api/map")
-//@RequiredArgsConstructor
-//@Validated
-//public class MapController {
-//
-//    private final MapCustomService mapCustomService;
-//
-//    @GetMapping("/details")
-//    @Operation(summary = "지도에서 장소 및 이벤트 정보 보기", description = "장소의 Latitude, Longitude 수령해 해당 장소의 명소와 이벤트를 조회합니다.")
-//    @ApiResponses({
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-//    })
-//    @Parameters({
-//            @Parameter(name = "latitude"),
-//            @Parameter(name = "longitude"),
-//    })
-//    public ApiResponse<MapResponseDTO.MapDetailDTO> getSearchedPlaceInfoList(
-//                                                                @CurrentUser User user,
-//                                                                @RequestParam Double latitude,
-//                                                                @RequestParam Double longitude) {
-//        return ApiResponse.onSuccess(mapCustomService.findAllMapDetails(user, latitude, longitude));
-//    }
-//}
+@RestController
+@RequestMapping("/api/map")
+@RequiredArgsConstructor
+@Validated
+public class MapController {
+
+    private final MapCustomService mapCustomService;
+
+    @GetMapping("/details")
+    @Operation(summary = "지도에서 장소 및 이벤트 정보 보기", description = "장소의 Latitude, Longitude 수령해 해당 장소의 명소와 이벤트를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "latitude"),
+            @Parameter(name = "longitude"),
+    })
+    public ApiResponse<MapResponseDTO.MapDetailDTO> getSearchedPlaceInfoList(
+                                                                @CurrentUser User user,
+                                                                @RequestParam Double latitude,
+                                                                @RequestParam Double longitude) {
+        return ApiResponse.onSuccess(mapCustomService.findAllMapDetails(user, latitude, longitude));
+    }
+}

--- a/src/main/java/com/otakumap/domain/map/converter/MapConverter.java
+++ b/src/main/java/com/otakumap/domain/map/converter/MapConverter.java
@@ -43,7 +43,8 @@ public class MapConverter {
                 .endDate(event.getEndDate())
                 .isLiked(isLiked)
                 .locationName(locationName)
-                .animationName(animation != null ? animation.getName() : "")
+                .animationId(animation.getId())
+                .animationName(animation.getName())
                 .hashtags(hashTags.stream().map(HashTag::getName).collect(Collectors.toList()))
                 .build();
     }
@@ -59,7 +60,8 @@ public class MapConverter {
                 .name(place.getName())
                 .detail(place.getDetail())
                 .isLiked(isLiked)
-                .animationName(animation != null ? animation.getName() : "")
+                .animationId(animation.getId())
+                .animationName(animation.getName())
                 .hashtags(hashTags.stream().map(HashTag::getName).collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/com/otakumap/domain/map/converter/MapConverter.java
+++ b/src/main/java/com/otakumap/domain/map/converter/MapConverter.java
@@ -4,7 +4,6 @@ import com.otakumap.domain.animation.entity.Animation;
 import com.otakumap.domain.event.entity.Event;
 import com.otakumap.domain.hash_tag.entity.HashTag;
 import com.otakumap.domain.image.converter.ImageConverter;
-import com.otakumap.domain.image.dto.ImageResponseDTO;
 import com.otakumap.domain.map.dto.MapResponseDTO;
 import com.otakumap.domain.place.entity.Place;
 import org.springframework.stereotype.Component;
@@ -30,9 +29,9 @@ public class MapConverter {
             String locationName,
             Animation animation,
             List<HashTag> hashTags) {
-        ImageResponseDTO.ImageDTO image = null;
+        String image = "";
         if(event.getThumbnailImage() != null) {
-            image = ImageConverter.toImageDTO(event.getThumbnailImage());
+            image = ImageConverter.toImageDTO(event.getThumbnailImage()).getFileUrl();
         }
 
         return MapResponseDTO.MapDetailEventDTO.builder()

--- a/src/main/java/com/otakumap/domain/map/dto/MapResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/map/dto/MapResponseDTO.java
@@ -1,6 +1,5 @@
 package com.otakumap.domain.map.dto;
 
-import com.otakumap.domain.image.dto.ImageResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,7 +32,7 @@ public class MapResponseDTO {
         private String locationName;
         private Long animationId;
         private String animationName;
-        private ImageResponseDTO.ImageDTO thumbnail;
+        private String thumbnail;
         private List<String> hashtags;
     }
 

--- a/src/main/java/com/otakumap/domain/map/dto/MapResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/map/dto/MapResponseDTO.java
@@ -31,6 +31,7 @@ public class MapResponseDTO {
         private LocalDate endDate;
         private Boolean isLiked;
         private String locationName;
+        private Long animationId;
         private String animationName;
         private ImageResponseDTO.ImageDTO thumbnail;
         private List<String> hashtags;
@@ -46,6 +47,7 @@ public class MapResponseDTO {
         private String name;
         private String detail;
         private Boolean isLiked;
+        private Long animationId;
         private String animationName;
         private List<String> hashtags;
     }

--- a/src/main/java/com/otakumap/domain/map/repository/MapRepositoryCustomImpl.java
+++ b/src/main/java/com/otakumap/domain/map/repository/MapRepositoryCustomImpl.java
@@ -1,76 +1,80 @@
-//package com.otakumap.domain.map.repository;
-//
-//import com.otakumap.domain.event.entity.Event;
-//import com.otakumap.domain.event.repository.EventRepository;
-//import com.otakumap.domain.event_like.repository.EventLikeRepository;
-//import com.otakumap.domain.map.converter.MapConverter;
-//import com.otakumap.domain.place.entity.Place;
-//import com.otakumap.domain.place.repository.PlaceRepository;
-//import com.otakumap.domain.map.dto.MapResponseDTO;
-//import com.otakumap.domain.animation.entity.Animation;
-//import com.otakumap.domain.mapping.PlaceAnimation;
-//import com.otakumap.domain.mapping.EventAnimation;
-//import com.otakumap.domain.hash_tag.entity.HashTag;
-//import com.otakumap.domain.mapping.EventHashTag;
-//import com.otakumap.domain.place_like.repository.PlaceLikeRepository;
-//import com.otakumap.domain.user.entity.User;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.stereotype.Repository;
-//
-//import java.util.ArrayList;
-//import java.util.List;
-//import java.util.concurrent.atomic.AtomicReference;
-//import java.util.stream.Collectors;
-//
-//@Repository
-//@RequiredArgsConstructor
-//public class MapRepositoryCustomImpl implements MapRepositoryCustom {
-//
-//    private final EventRepository eventRepository;
-//    private final PlaceRepository placeRepository;
-//    private final EventLikeRepository eventLikeRepository;
-//    private final PlaceLikeRepository placeLikeRepository;
-//
-//    @Override
-//    public MapResponseDTO.MapDetailDTO findAllMapDetails(User user, Double latitude, Double longitude) {
-//        List<Event> eventList = eventRepository.findEventsByLocationWithAnimations(latitude, longitude);
-//        List<MapResponseDTO.MapDetailEventDTO> eventDTOs = eventList.stream().map(event -> {
-//            Boolean isLiked = Boolean.FALSE;
-//            List<HashTag> eventHashTags = event.getEventHashTagList().stream()
-//                    .map(EventHashTag::getHashTag)
-//                    .collect(Collectors.toList());
-//
-//            List<Animation> eventAnimations = event.getEventAnimationList().stream()
-//                    .map(EventAnimation::getAnimation)
-//                    .toList();
-//            if(user!=null) {
-//                isLiked = eventLikeRepository.existsByUserAndEvent(user, event);
-//            }
-//            return MapConverter.toMapDetailEventDTO(event, isLiked, event.getEventLocation().getName(), eventAnimations.isEmpty() ? null : eventAnimations.get(0), eventHashTags);
-//        }).collect(Collectors.toList());
-//
-//        List<Place> placeList = placeRepository.findPlacesByLocationWithAnimations(latitude, longitude);
-//        List<MapResponseDTO.MapDetailPlaceDTO> placeDTOs = placeList.stream().map(place -> {
-//            List<HashTag> placeHashTags = new ArrayList<>();
-//            AtomicReference<Boolean> isLiked = new AtomicReference<>(Boolean.FALSE);
-//
-//            place.getPlaceAnimationList().forEach(placeAnimation -> {
-//                placeAnimation.getPlaceAnimationHashTags().forEach(hashTag -> {
-//                    placeHashTags.add(hashTag.getHashTag());
-//                });
-//
-//                if(user!=null) {
-//                    isLiked.set(placeLikeRepository.existsByUserAndPlaceAnimation(user, placeAnimation));
-//                }
-//            });
-//
-//            List<Animation> placeAnimations = place.getPlaceAnimationList().stream()
-//                    .map(PlaceAnimation::getAnimation)
-//                    .toList();
-//
-//            return MapConverter.toMapDetailPlaceDTO(place, isLiked.get(), placeAnimations.isEmpty() ? null : placeAnimations.get(0), placeHashTags);
-//        }).collect(Collectors.toList());
-//
-//        return MapConverter.toMapDetailDTO(eventDTOs, placeDTOs);
-//    }
-//}
+package com.otakumap.domain.map.repository;
+
+import com.otakumap.domain.event.entity.Event;
+import com.otakumap.domain.event.repository.EventRepository;
+import com.otakumap.domain.event_like.repository.EventLikeRepository;
+import com.otakumap.domain.map.converter.MapConverter;
+import com.otakumap.domain.mapping.AnimationHashtag;
+import com.otakumap.domain.place.entity.Place;
+import com.otakumap.domain.place.repository.PlaceRepository;
+import com.otakumap.domain.map.dto.MapResponseDTO;
+import com.otakumap.domain.animation.entity.Animation;
+import com.otakumap.domain.mapping.PlaceAnimation;
+import com.otakumap.domain.mapping.EventAnimation;
+import com.otakumap.domain.hash_tag.entity.HashTag;
+import com.otakumap.domain.place_like.repository.PlaceLikeRepository;
+import com.otakumap.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class MapRepositoryCustomImpl implements MapRepositoryCustom {
+
+    private final EventRepository eventRepository;
+    private final PlaceRepository placeRepository;
+    private final EventLikeRepository eventLikeRepository;
+    private final PlaceLikeRepository placeLikeRepository;
+
+    @Override
+    public MapResponseDTO.MapDetailDTO findAllMapDetails(User user, Double latitude, Double longitude) {
+        List<Event> eventList = eventRepository.findEventsByLocationWithAnimations(latitude, longitude);
+        List<MapResponseDTO.MapDetailEventDTO> eventDTOs = eventList.stream().map(event -> {
+            Boolean isLiked = Boolean.FALSE;
+
+            List<Animation> eventAnimations = event.getEventAnimationList().stream()
+                    .map(EventAnimation::getAnimation)
+                    .toList();
+
+            Animation eventAnimation = (!eventAnimations.isEmpty() ? eventAnimations.get(0) : null);
+            List<HashTag> eventHashTags = new ArrayList<>();
+            if(eventAnimation != null) {
+                eventHashTags = eventAnimation.getAnimationHashtags().stream()
+                        .map(AnimationHashtag::getHashTag)
+                        .toList();
+            }
+            
+            if(user!=null) {
+                isLiked = eventLikeRepository.existsByUserAndEvent(user, event);
+            }
+            return MapConverter.toMapDetailEventDTO(event, isLiked, event.getEventLocation().getName(), eventAnimation, eventHashTags);
+        }).collect(Collectors.toList());
+
+        List<Place> placeList = placeRepository.findPlacesByLocationWithAnimations(latitude, longitude);
+        List<MapResponseDTO.MapDetailPlaceDTO> placeDTOs = placeList.stream().map(place -> {
+            List<HashTag> placeHashTags = new ArrayList<>();
+            AtomicReference<Boolean> isLiked = new AtomicReference<>(Boolean.FALSE);
+
+            place.getPlaceAnimationList().forEach(placeAnimation -> {
+                placeAnimation.getAnimation().getAnimationHashtags().forEach(hashTag -> placeHashTags.add(hashTag.getHashTag()));
+
+                if(user!=null) {
+                    isLiked.set(placeLikeRepository.existsByUserAndPlaceAnimation(user, placeAnimation));
+                }
+            });
+
+            List<Animation> placeAnimations = place.getPlaceAnimationList().stream()
+                    .map(PlaceAnimation::getAnimation)
+                    .toList();
+
+            return MapConverter.toMapDetailPlaceDTO(place, isLiked.get(), placeAnimations.get(0), placeHashTags);
+        }).collect(Collectors.toList());
+
+        return MapConverter.toMapDetailDTO(eventDTOs, placeDTOs);
+    }
+}

--- a/src/main/java/com/otakumap/domain/map/service/MapCustomServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/map/service/MapCustomServiceImpl.java
@@ -7,15 +7,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-//@Service
-//@RequiredArgsConstructor
-//@Transactional(readOnly = true)
-//public class MapCustomServiceImpl implements MapCustomService {
-//
-//    private final MapRepositoryCustom mapRepositoryCustom;
-//
-//    @Override
-//    public MapResponseDTO.MapDetailDTO findAllMapDetails(User user, Double latitude, Double longitude) {
-//        return mapRepositoryCustom.findAllMapDetails(user, latitude, longitude);
-//    }
-//}
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MapCustomServiceImpl implements MapCustomService {
+
+    private final MapRepositoryCustom mapRepositoryCustom;
+
+    @Override
+    public MapResponseDTO.MapDetailDTO findAllMapDetails(User user, Double latitude, Double longitude) {
+        return mapRepositoryCustom.findAllMapDetails(user, latitude, longitude);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #187 

## 📝 작업 내용
- 해시태그 엔티티 변경에 따라 지도에서 장소 및 이벤트 정보 보기 API 수정
- 애니메이션 아이디도 같이 반환하도록 수정

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
테스트 결과
<img width="950" alt="Screenshot 2025-02-18 at 10 30 14" src="https://github.com/user-attachments/assets/c60947e3-711f-435c-9e18-2bbb62172286" />
<img width="952" alt="Screenshot 2025-02-18 at 10 29 40" src="https://github.com/user-attachments/assets/b0b46b8d-5ee1-4628-ac48-b0883a8b94e6" />