### PR TITLE
Feat: 카테고리 페이지에서 이벤트를 이벤트명/작품명으로 검색 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/event/controller/EventController.java
+++ b/src/main/java/com/otakumap/domain/event/controller/EventController.java
@@ -54,4 +54,14 @@ public class EventController {
             @RequestParam Integer size) {
         return ApiResponse.onSuccess(EventConverter.toEventSearchResultDTO(eventCustomService.searchEventByCategory(genre, status, type, page, size)));
     }
+
+    @Operation(summary = "이벤트 이름/작품명으로 이벤트 검색", description = "이벤트 이름과 작품명으로 이벤트를 검색합니다.")
+    @GetMapping("/events/search")
+    public ApiResponse<EventResponseDTO.EventSearchResultDTO> searchEventByKeyword(
+            @Parameter(description = "검색어") @RequestParam String keyword,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam Integer page,
+            @Parameter(description = "한 페이지에 가져올 이벤트 개수", example = "10") @RequestParam Integer size) {
+
+        return ApiResponse.onSuccess(eventQueryService.searchEventByKeyword(keyword, page, size));
+    }
 }

--- a/src/main/java/com/otakumap/domain/event/service/EventQueryService.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventQueryService.java
@@ -4,4 +4,5 @@ import com.otakumap.domain.event.dto.EventResponseDTO;
 
 public interface EventQueryService {
     EventResponseDTO.EventDetailDTO getEventDetail(Long eventId);
+    EventResponseDTO.EventSearchResultDTO searchEventByKeyword(String keyword, Integer page, Integer size);
 }

--- a/src/main/java/com/otakumap/domain/event/service/EventQueryServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/event/service/EventQueryServiceImpl.java
@@ -4,9 +4,12 @@ import com.otakumap.domain.event.converter.EventConverter;
 import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.event.entity.Event;
 import com.otakumap.domain.event.repository.EventRepository;
+import com.otakumap.domain.search.repository.SearchRepositoryCustom;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
 import com.otakumap.global.apiPayload.exception.handler.EventHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,7 @@ import java.util.stream.Collectors;
 public class EventQueryServiceImpl implements EventQueryService{
 
     private final EventRepository eventRepository;
+    private final SearchRepositoryCustom searchRepository;
 
     @Override
     public EventResponseDTO.EventDetailDTO getEventDetail(Long eventId) {
@@ -27,5 +31,13 @@ public class EventQueryServiceImpl implements EventQueryService{
                 .collect(Collectors.joining(", "));
 
         return EventConverter.toEventDetailDTO(event, animationName);
+    }
+
+    @Override
+    public EventResponseDTO.EventSearchResultDTO searchEventByKeyword(String keyword, Integer page, Integer size) {
+
+        Page<EventResponseDTO.EventDTO> pagedEventDTOs = searchRepository.searchAllEventsByKeyword(keyword, PageRequest.of(page, size));
+
+        return EventConverter.toEventSearchResultDTO(pagedEventDTOs);
     }
 }

--- a/src/main/java/com/otakumap/domain/search/repository/SearchRepositoryCustom.java
+++ b/src/main/java/com/otakumap/domain/search/repository/SearchRepositoryCustom.java
@@ -1,11 +1,19 @@
 package com.otakumap.domain.search.repository;
 
+import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.event.entity.Event;
 import com.otakumap.domain.place.entity.Place;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface SearchRepositoryCustom {
+    // 진행 전 or 진행 중인 이벤트에서 검색
     List<Event> searchEventsByKeyword(String keyword);
+
+    // 모든 이벤트에서 검색
+    Page<EventResponseDTO.EventDTO> searchAllEventsByKeyword(String keyword, Pageable pageRequest);
+
     List<Place> searchPlacesByKeyword(String keyword);
 }

--- a/src/main/java/com/otakumap/domain/search/repository/SearchRepositoryCustomImpl.java
+++ b/src/main/java/com/otakumap/domain/search/repository/SearchRepositoryCustomImpl.java
@@ -2,6 +2,8 @@ package com.otakumap.domain.search.repository;
 
 
 import com.otakumap.domain.animation.entity.QAnimation;
+import com.otakumap.domain.event.converter.EventConverter;
+import com.otakumap.domain.event.dto.EventResponseDTO;
 import com.otakumap.domain.event.entity.Event;
 import com.otakumap.domain.event.entity.QEvent;
 import com.otakumap.domain.event.entity.enums.EventStatus;
@@ -9,9 +11,16 @@ import com.otakumap.domain.mapping.QEventAnimation;
 import com.otakumap.domain.mapping.QPlaceAnimation;
 import com.otakumap.domain.place.entity.Place;
 import com.otakumap.domain.place.entity.QPlace;
+import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.SearchHandler;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,6 +32,7 @@ public class SearchRepositoryCustomImpl implements SearchRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
+    // 진행 전 or 진행 중인 이벤트 중에서 검색
     public List<Event> searchEventsByKeyword(String keyword) {
 
         QEvent qEvent = QEvent.event;
@@ -42,6 +52,40 @@ public class SearchRepositoryCustomImpl implements SearchRepositoryCustom {
     }
 
     @Override
+    // 모든 이벤트에서 검색
+    public Page<EventResponseDTO.EventDTO> searchAllEventsByKeyword(String keyword, Pageable pageRequest) {
+
+        QEvent qEvent = QEvent.event;
+        QEventAnimation qEventAnimation = QEventAnimation.eventAnimation;
+        QAnimation qAnimation = QAnimation.animation;
+
+        BooleanBuilder condition = new BooleanBuilder();
+        condition.or(qEvent.title.containsIgnoreCase(keyword))
+                .or(qAnimation.name.containsIgnoreCase(keyword));
+
+        // 전체 건수 조회
+        Long total = createBaseQuery(qEvent.id.count(), qEvent, qEventAnimation, qAnimation, condition)
+                .fetchOne();
+        if(total == null) {
+            throw new SearchHandler(ErrorStatus.EVENT_SEARCH_NOT_FOUND);
+        }
+
+        List<Event> events = queryFactory.selectFrom(qEvent)
+                .leftJoin(qEventAnimation).on(qEventAnimation.event.eq(qEvent))
+                .leftJoin(qAnimation).on(qEventAnimation.animation.eq(qAnimation))
+                .where(condition)
+                .offset(pageRequest.getOffset())
+                .limit(pageRequest.getPageSize())
+                .fetch();
+
+        List<EventResponseDTO.EventDTO> content = events.stream()
+                .map(EventConverter::toEventDTO)
+                .toList();
+
+        return new PageImpl<>(content, pageRequest, total);
+    }
+
+    @Override
     public List<Place> searchPlacesByKeyword(String keyword) {
 
         QPlace qPlace = QPlace.place;
@@ -57,5 +101,15 @@ public class SearchRepositoryCustomImpl implements SearchRepositoryCustom {
                 .leftJoin(qAnimation).on(qPlaceAnimation.animation.eq(qAnimation))
                 .where(condition)
                 .fetch();
+    }
+
+    private <T> JPAQuery<T> createBaseQuery(Expression<T> selectClause, QEvent qEvent,
+                                            QEventAnimation qEventAnimation,
+                                            QAnimation qAnimation, BooleanBuilder condition) {
+        return queryFactory.select(selectClause)
+                .from(qEvent)
+                .leftJoin(qEventAnimation).on(qEventAnimation.event.eq(qEvent))
+                .leftJoin(qAnimation).on(qEventAnimation.animation.eq(qAnimation))
+                .where(condition);
     }
 }

--- a/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
@@ -59,6 +59,9 @@ public enum ErrorStatus implements BaseErrorCode {
     EVENT_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "EVENT4006", "존재하지 않는 이벤트 종류입니다."),
     EVENT_STATUS_NOT_FOUND(HttpStatus.BAD_REQUEST, "EVENT4007", "존재하지 않는 이벤트 상태입니다."),
 
+    // 이벤트 검색 관련 에러
+    EVENT_SEARCH_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT4008", "검색된 이벤트가 없습니다."),
+
     // 후기 검색 관련 에러
     REVIEW_SEARCH_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH4001", "검색된 후기가 없습니다."),
 


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #206 

## 📝 작업 내용
-   카테고리 페이지에서 이벤트를 이벤트명/작품명으로 검색하는 API를 구현했습니다.
<img width="473" alt="image" src="https://github.com/user-attachments/assets/8e0105d9-2968-4ecc-8e71-fb0e2746a095" />


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
