### PR TITLE
Feat: 후기 구매 API 구현

### DIFF
--- a/src/main/java/com/otakumap/domain/event_review/entity/EventReview.java
+++ b/src/main/java/com/otakumap/domain/event_review/entity/EventReview.java
@@ -37,6 +37,9 @@ public class EventReview extends BaseEntity {
     @Column(columnDefinition = "bigint default 0 not null")
     private Long view;
 
+    @Column(columnDefinition = "bigint default 0 not null")
+    private Long price;
+
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "eventReview")
     private List<Image> images = new ArrayList<>();
 

--- a/src/main/java/com/otakumap/domain/event_review/repository/EventReviewRepository.java
+++ b/src/main/java/com/otakumap/domain/event_review/repository/EventReviewRepository.java
@@ -16,4 +16,7 @@ public interface EventReviewRepository extends JpaRepository<EventReview, Long> 
     Optional<EventReview> findByRouteId(Long routeId);
     @Query("SELECT er.user FROM EventReview er WHERE er.route.id = :routeId")
     Optional<User> findUserByRouteId(@Param("routeId") Long routeId);
+    @Query("SELECT er.user FROM EventReview er WHERE er.id = :reviewId")
+    User findUserById(@Param("reviewId") Long reviewId);
 }
+

--- a/src/main/java/com/otakumap/domain/place_review/entity/PlaceReview.java
+++ b/src/main/java/com/otakumap/domain/place_review/entity/PlaceReview.java
@@ -36,6 +36,10 @@ public class PlaceReview extends BaseEntity {
     @Column(columnDefinition = "bigint default 0 not null")
     private Long view;
 
+    @Column(columnDefinition = "bigint default 0 not null")
+    private Long price;
+
+
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "placeReview", orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 

--- a/src/main/java/com/otakumap/domain/place_review/entity/PlaceReview.java
+++ b/src/main/java/com/otakumap/domain/place_review/entity/PlaceReview.java
@@ -39,7 +39,6 @@ public class PlaceReview extends BaseEntity {
     @Column(columnDefinition = "bigint default 0 not null")
     private Long price;
 
-
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "placeReview", orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 

--- a/src/main/java/com/otakumap/domain/place_review/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/otakumap/domain/place_review/repository/PlaceReviewRepository.java
@@ -1,15 +1,12 @@
 package com.otakumap.domain.place_review.repository;
 
 import com.otakumap.domain.place_review.entity.PlaceReview;
-import com.otakumap.domain.route.entity.Route;
 import com.otakumap.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 import java.util.Optional;
 
@@ -20,5 +17,6 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long>,
     Optional<PlaceReview> findByRouteId(Long routeId);
     @Query("SELECT pr.user FROM PlaceReview pr WHERE pr.route.id = :routeId")
     Optional<User> findUserByRouteId(@Param("routeId") Long routeId);
-    PlaceReview findAllByRoute(Route route);
+    @Query("SELECT pr.user FROM PlaceReview pr WHERE pr.id = :reviewId")
+    User findUserById(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/com/otakumap/domain/point/entity/Point.java
+++ b/src/main/java/com/otakumap/domain/point/entity/Point.java
@@ -46,7 +46,7 @@ public class Point extends BaseEntity {
     private String chargedBy;
 
     // 주문 ID
-    @Column(name = "merchant_uid", unique = true, nullable = false)
+    @Column(name = "merchant_uid")
     private String merchantUid;
 
     // Iamport 결제 고유 ID
@@ -59,6 +59,13 @@ public class Point extends BaseEntity {
 
     @OneToMany(mappedBy = "point", cascade = CascadeType.ALL)
     private List<Transaction> transactionList = new ArrayList<>();
+
+    public Point(Long point, LocalDateTime chargedAt, PaymentStatus status, User user) {
+        this.point = point;
+        this.chargedAt = chargedAt;
+        this.status = status;
+        this.user = user;
+    }
 
     public Point(User user, String merchantUid, Long point) {
         this.user = user;

--- a/src/main/java/com/otakumap/domain/point/entity/Point.java
+++ b/src/main/java/com/otakumap/domain/point/entity/Point.java
@@ -46,7 +46,7 @@ public class Point extends BaseEntity {
     private String chargedBy;
 
     // 주문 ID
-    @Column(name = "merchant_uid")
+    @Column(name = "merchant_uid", unique = true, nullable = false)
     private String merchantUid;
 
     // Iamport 결제 고유 ID

--- a/src/main/java/com/otakumap/domain/point/entity/Point.java
+++ b/src/main/java/com/otakumap/domain/point/entity/Point.java
@@ -65,4 +65,17 @@ public class Point extends BaseEntity {
         this.merchantUid = merchantUid;
         this.point = point;
     }
+
+    public void addPoint(Long point) {
+        this.point += point;
+    }
+
+    public Long subPoint(Long point) {
+        this.point -= point;
+        return this.point;
+    }
+
+    public boolean isAffordable(Long point) {
+        return this.point >= point;
+    }
 }

--- a/src/main/java/com/otakumap/domain/reviews/controller/ReviewController.java
+++ b/src/main/java/com/otakumap/domain/reviews/controller/ReviewController.java
@@ -82,4 +82,16 @@ public class ReviewController {
         ReviewResponseDTO.CreatedReviewDTO createdReview = reviewCommandService.createReview(request, user, images);
         return ApiResponse.onSuccess(createdReview);
     }
+
+    @PostMapping(value = "/reviews/purchase")
+    @Operation(summary = "후기 구매", description = "후기를 구매합니다.")
+    @Parameters({
+            @Parameter(name = "reviewId", description = "이벤트 or 명소의 후기 id 입니다."),
+            @Parameter(name = "type", description = "리뷰의 종류를 특정합니다. 'EVENT' 또는 'PLACE' 여야 합니다.")
+    })
+    public ApiResponse<ReviewResponseDTO.PurchaseReviewDTO> purchaseReview(@CurrentUser User user,
+                                                                          @RequestParam @ValidReviewId Long reviewId,
+                                                        @RequestParam(defaultValue = "PLACE") ReviewType type) {
+        return ApiResponse.onSuccess(reviewCommandService.purchaseReview(user, reviewId, type));
+    }
 }

--- a/src/main/java/com/otakumap/domain/reviews/converter/ReviewConverter.java
+++ b/src/main/java/com/otakumap/domain/reviews/converter/ReviewConverter.java
@@ -5,7 +5,6 @@ import com.otakumap.domain.event_review.entity.EventReview;
 import com.otakumap.domain.image.converter.ImageConverter;
 import com.otakumap.domain.image.dto.ImageResponseDTO;
 import com.otakumap.domain.image.entity.Image;
-import com.otakumap.domain.mapping.EventAnimation;
 import com.otakumap.domain.mapping.EventReviewPlace;
 import com.otakumap.domain.mapping.PlaceAnimation;
 import com.otakumap.domain.mapping.PlaceReviewPlace;
@@ -114,6 +113,7 @@ public class ReviewConverter {
                 .title(eventReview.getTitle())
                 .view(eventReview.getView())
                 .content(eventReview.getContent())
+                .price(eventReview.getPrice())
                 .reviewImages(eventReview.getImages().stream()
                         .filter(Objects::nonNull)
                         .map(ImageConverter::toImageDTO)

--- a/src/main/java/com/otakumap/domain/reviews/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/reviews/dto/ReviewResponseDTO.java
@@ -57,6 +57,7 @@ public class ReviewResponseDTO {
         String title;
         Long view;
         String content;
+        Long price;
         List<ImageResponseDTO.ImageDTO> reviewImages;
 
         String userName;

--- a/src/main/java/com/otakumap/domain/reviews/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/otakumap/domain/reviews/dto/ReviewResponseDTO.java
@@ -17,7 +17,7 @@ public class ReviewResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Top7ReviewPreViewListDTO {
-        List<Top7ReviewPreViewDTO> reviews;
+        private List<Top7ReviewPreViewDTO> reviews;
     }
 
     @Builder
@@ -25,12 +25,12 @@ public class ReviewResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Top7ReviewPreViewDTO {
-        Long id;
-        String title;
-        ImageResponseDTO.ImageDTO reviewImage;
-        Long view;
-        String type;
-        LocalDateTime createdAt;
+        private Long id;
+        private String title;
+        private ImageResponseDTO.ImageDTO reviewImage;
+        private Long view;
+        private String type;
+        private LocalDateTime createdAt;
     }
 
     @Builder
@@ -74,5 +74,13 @@ public class ReviewResponseDTO {
         Long reviewId;
         String title;
         LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PurchaseReviewDTO {
+        private Long remainingPoints;
     }
 }

--- a/src/main/java/com/otakumap/domain/reviews/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/otakumap/domain/reviews/repository/ReviewRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.otakumap.domain.reviews.repository;
 
 import com.otakumap.domain.reviews.dto.ReviewResponseDTO;
+import com.otakumap.domain.reviews.enums.ReviewType;
+import com.otakumap.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 
 public interface ReviewRepositoryCustom {
     Page<ReviewResponseDTO.SearchedReviewPreViewDTO> getReviewsByKeyword(String keyword, int page, int size, String sort);
     ReviewResponseDTO.Top7ReviewPreViewListDTO getTop7Reviews();
+    ReviewResponseDTO.PurchaseReviewDTO purchaseReview(User user, Long reviewId, ReviewType type);
 }

--- a/src/main/java/com/otakumap/domain/reviews/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/otakumap/domain/reviews/repository/ReviewRepositoryImpl.java
@@ -4,16 +4,27 @@ import com.otakumap.domain.animation.entity.QAnimation;
 import com.otakumap.domain.event.entity.QEvent;
 import com.otakumap.domain.event_review.entity.EventReview;
 import com.otakumap.domain.event_review.entity.QEventReview;
+import com.otakumap.domain.event_review.repository.EventReviewRepository;
 import com.otakumap.domain.mapping.QEventAnimation;
 import com.otakumap.domain.mapping.QPlaceAnimation;
 import com.otakumap.domain.mapping.QPlaceReviewPlace;
 import com.otakumap.domain.place.entity.QPlace;
 import com.otakumap.domain.place_review.entity.PlaceReview;
 import com.otakumap.domain.place_review.entity.QPlaceReview;
+import com.otakumap.domain.place_review.repository.PlaceReviewRepository;
+import com.otakumap.domain.point.entity.Point;
+import com.otakumap.domain.point.repository.PointRepository;
 import com.otakumap.domain.reviews.converter.ReviewConverter;
 import com.otakumap.domain.reviews.dto.ReviewResponseDTO;
+import com.otakumap.domain.reviews.enums.ReviewType;
+import com.otakumap.domain.transaction.entity.Transaction;
+import com.otakumap.domain.transaction.enums.TransactionType;
+import com.otakumap.domain.transaction.repository.TransactionRepository;
+import com.otakumap.domain.user.entity.User;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
+import com.otakumap.global.apiPayload.exception.handler.ReviewHandler;
 import com.otakumap.global.apiPayload.exception.handler.SearchHandler;
+import com.otakumap.global.apiPayload.exception.handler.TransactionHandler;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -26,6 +37,7 @@ import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -34,6 +46,10 @@ import java.util.stream.Stream;
 public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final EventReviewRepository eventReviewRepository;
+    private final PointRepository pointRepository;
+    private final PlaceReviewRepository placeReviewRepository;
+    private final TransactionRepository transactionRepository;
 
     @Override
     public Page<ReviewResponseDTO.SearchedReviewPreViewDTO> getReviewsByKeyword(String keyword, int page, int size, String sort) {
@@ -143,5 +159,67 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 .collect(Collectors.toList());
 
         return ReviewConverter.top7ReviewPreViewListDTO(top7Reviews);
+    }
+
+    @Override
+    public ReviewResponseDTO.PurchaseReviewDTO purchaseReview(User user, Long reviewId, ReviewType type) {
+        Point buyerPoint = pointRepository.findTopByUserOrderByCreatedAtDesc(user);
+        // 이벤트 리뷰인 경우
+        if(type == ReviewType.EVENT) {
+            EventReview review = eventReviewRepository.findById(reviewId)
+                    .orElseThrow(() -> new ReviewHandler(ErrorStatus.REVIEW_NOT_FOUND));
+            if (transactionRepository.existsByPoint_UserAndEventReview(user, review)) {
+                throw new TransactionHandler(ErrorStatus.PURCHASE_ALREADY_EXISTS);
+            }
+
+            return processReviewPurchase(user, buyerPoint, review, review.getPrice(),
+                    eventReviewRepository.findUserById(reviewId), true);
+        }
+        // 장소 리뷰인 경우
+        PlaceReview review = placeReviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewHandler(ErrorStatus.REVIEW_NOT_FOUND));
+        if (transactionRepository.existsByPoint_UserAndPlaceReview(user, review)) {
+            throw new TransactionHandler(ErrorStatus.PURCHASE_ALREADY_EXISTS);
+        }
+
+        return processReviewPurchase(user, buyerPoint, review, review.getPrice(),
+                placeReviewRepository.findUserById(reviewId), false);
+    }
+
+    private ReviewResponseDTO.PurchaseReviewDTO processReviewPurchase(
+            User user, Point buyerPoint, Object review, Long price, User seller, boolean isEventReview) {
+        // 무료 글인 경우
+        if(price == 0L) {
+            throw new TransactionHandler(ErrorStatus.PURCHASE_FREE_CONTENT);
+        }
+        // 포인트 부족 확인
+        if (!buyerPoint.isAffordable(price)) {
+            throw new TransactionHandler(ErrorStatus.PURCHASE_INSUFFICIENT_POINTS);
+        }
+        // 글쓴이와 구매자가 다른지 확인
+        if(Objects.equals(user.getId(), seller.getId())) {
+            throw new TransactionHandler(ErrorStatus.PURCHASE_SELF_CONTENT);
+        }
+
+        Point sellerPoint = pointRepository.findTopByUserOrderByCreatedAtDesc(seller);
+
+        int priceInt = Math.toIntExact(price);
+        // 거래 내역 저장(사용한 것과 번 것)
+        if (isEventReview) {
+            transactionRepository.save(new Transaction(buyerPoint, TransactionType.USAGE, priceInt, (EventReview) review, null));
+            transactionRepository.save(new Transaction(sellerPoint, TransactionType.EARNING, priceInt, (EventReview) review, null));
+        } else {
+            transactionRepository.save(new Transaction(buyerPoint, TransactionType.USAGE, priceInt, null, (PlaceReview) review));
+            transactionRepository.save(new Transaction(sellerPoint, TransactionType.EARNING, priceInt, null, (PlaceReview) review));
+        }
+
+        // 포인트 수정 후 업데이트
+        sellerPoint.addPoint(price);
+        Long remainingPoints = buyerPoint.subPoint(price);
+        pointRepository.save(sellerPoint);
+        pointRepository.save(buyerPoint);
+        return ReviewResponseDTO.PurchaseReviewDTO.builder()
+                .remainingPoints(remainingPoints)
+                .build();
     }
 }

--- a/src/main/java/com/otakumap/domain/reviews/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/otakumap/domain/reviews/repository/ReviewRepositoryImpl.java
@@ -169,7 +169,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         // 이벤트 리뷰인 경우
         if(type == ReviewType.EVENT) {
             EventReview review = eventReviewRepository.findById(reviewId)
-                    .orElseThrow(() -> new ReviewHandler(ErrorStatus.REVIEW_NOT_FOUND));
+                    .orElseThrow(() -> new ReviewHandler(ErrorStatus.EVENT_REVIEW_NOT_FOUND));
             if (transactionRepository.existsByPoint_UserAndEventReview(user, review)) {
                 throw new TransactionHandler(ErrorStatus.PURCHASE_ALREADY_EXISTS);
             }
@@ -179,7 +179,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         }
         // 장소 리뷰인 경우
         PlaceReview review = placeReviewRepository.findById(reviewId)
-                .orElseThrow(() -> new ReviewHandler(ErrorStatus.REVIEW_NOT_FOUND));
+                .orElseThrow(() -> new ReviewHandler(ErrorStatus.PLACE_REVIEW_NOT_FOUND));
         if (transactionRepository.existsByPoint_UserAndPlaceReview(user, review)) {
             throw new TransactionHandler(ErrorStatus.PURCHASE_ALREADY_EXISTS);
         }
@@ -199,12 +199,12 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             throw new TransactionHandler(ErrorStatus.PURCHASE_INSUFFICIENT_POINTS);
         }
         // 글쓴이와 구매자가 다른지 확인
-        if(Objects.equals(user.getId(), seller.getId())) {
+        if (Objects.equals(user.getId(), seller.getId())) {
             throw new TransactionHandler(ErrorStatus.PURCHASE_SELF_CONTENT);
         }
 
         Point sellerPoint = pointRepository.findTopByUserOrderByCreatedAtDesc(seller);
-        if(sellerPoint == null) {
+        if (sellerPoint == null) {
             sellerPoint = new Point(0L, LocalDateTime.now(), PaymentStatus.PAID, seller);
         }
 

--- a/src/main/java/com/otakumap/domain/reviews/service/ReviewCommandService.java
+++ b/src/main/java/com/otakumap/domain/reviews/service/ReviewCommandService.java
@@ -2,9 +2,11 @@ package com.otakumap.domain.reviews.service;
 
 import com.otakumap.domain.reviews.dto.ReviewRequestDTO;
 import com.otakumap.domain.reviews.dto.ReviewResponseDTO;
+import com.otakumap.domain.reviews.enums.ReviewType;
 import com.otakumap.domain.user.entity.User;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ReviewCommandService {
     ReviewResponseDTO.CreatedReviewDTO createReview(ReviewRequestDTO.CreateDTO request, User user, MultipartFile[] images);
+    ReviewResponseDTO.PurchaseReviewDTO purchaseReview(User user, Long reviewId, ReviewType type);
 }

--- a/src/main/java/com/otakumap/domain/reviews/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/reviews/service/ReviewCommandServiceImpl.java
@@ -18,6 +18,7 @@ import com.otakumap.domain.reviews.converter.ReviewConverter;
 import com.otakumap.domain.reviews.dto.ReviewRequestDTO;
 import com.otakumap.domain.reviews.dto.ReviewResponseDTO;
 import com.otakumap.domain.reviews.enums.ReviewType;
+import com.otakumap.domain.reviews.repository.ReviewRepositoryCustom;
 import com.otakumap.domain.route.converter.RouteConverter;
 import com.otakumap.domain.route.entity.Route;
 import com.otakumap.domain.route.repository.RouteRepository;
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ReviewCommandServiceImpl implements ReviewCommandService {
+    private final ReviewRepositoryCustom reviewRepositoryCustom;
     private final PlaceReviewRepository placeReviewRepository;
     private final EventReviewRepository eventReviewRepository;
     private final AnimationRepository animationRepository;
@@ -135,5 +137,10 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
         } else {
             throw new ReviewHandler(ErrorStatus.INVALID_REVIEW_TYPE);
         }
+    }
+
+    @Override
+    public ReviewResponseDTO.PurchaseReviewDTO purchaseReview(User user, Long reviewId, ReviewType type) {
+        return reviewRepositoryCustom.purchaseReview(user, reviewId, type);
     }
 }

--- a/src/main/java/com/otakumap/domain/transaction/entity/Transaction.java
+++ b/src/main/java/com/otakumap/domain/transaction/entity/Transaction.java
@@ -41,4 +41,16 @@ public class Transaction extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_review_id", referencedColumnName = "id")
     private PlaceReview placeReview;
+
+    public Transaction(Point point, TransactionType type, int amount, EventReview eventReview, PlaceReview placeReview) {
+        this.point = point;
+        this.type = type;
+        this.amount = amount;
+
+        if(eventReview != null) {
+            this.eventReview = eventReview;
+        } else {
+            this.placeReview = placeReview;
+        }
+    }
 }

--- a/src/main/java/com/otakumap/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/otakumap/domain/transaction/repository/TransactionRepository.java
@@ -1,5 +1,7 @@
 package com.otakumap.domain.transaction.repository;
 
+import com.otakumap.domain.event_review.entity.EventReview;
+import com.otakumap.domain.place_review.entity.PlaceReview;
 import com.otakumap.domain.transaction.entity.Transaction;
 import com.otakumap.domain.transaction.enums.TransactionType;
 import com.otakumap.domain.user.entity.User;
@@ -10,4 +12,6 @@ import java.util.List;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long>{
     List<Transaction> findAllByPoint_UserAndType(User user, TransactionType type, Pageable pageRequest);
+    Boolean existsByPoint_UserAndEventReview(User user, EventReview review);
+    Boolean existsByPoint_UserAndPlaceReview(User user, PlaceReview review);
 }

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -3,7 +3,7 @@ package com.otakumap.domain.user.entity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.otakumap.domain.image.entity.Image;
 import com.otakumap.domain.place_like.entity.PlaceLike;
-import com.otakumap.domain.route.entity.Route;
+import com.otakumap.domain.point.entity.Point;
 import com.otakumap.domain.route_like.entity.RouteLike;
 import com.otakumap.domain.user.entity.enums.Role;
 import com.otakumap.domain.user.entity.enums.SocialType;
@@ -79,6 +79,9 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<RouteLike> routeLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Point> points = new ArrayList<>();
 
     public void encodePassword(String password) {
         this.password = password;

--- a/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/otakumap/global/apiPayload/code/status/ErrorStatus.java
@@ -112,7 +112,13 @@ public enum ErrorStatus implements BaseErrorCode {
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT4001", "결제 정보를 찾을 수 없습니다."),
     PAYMENT_STATUS_INVALID(HttpStatus.BAD_REQUEST, "PAYMENT4002", "결제 상태가 유효하지 않습니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT4003", "결제 금액이 일치하지 않습니다."),
-    PAYMENT_DUPLICATE(HttpStatus.BAD_REQUEST, "PAYMENT4004", "이미 처리된 결제입니다.");
+    PAYMENT_DUPLICATE(HttpStatus.BAD_REQUEST, "PAYMENT4004", "이미 처리된 결제입니다."),
+
+    // 내부 결제 관련 에러
+    PURCHASE_FREE_CONTENT(HttpStatus.BAD_REQUEST, "PURCHASE4001", "무료이므로 결제가 불가능합니다."),
+    PURCHASE_INSUFFICIENT_POINTS(HttpStatus.FORBIDDEN, "PURCHASE4002", "포인트가 모자라 결제가 불가능합니다."),
+    PURCHASE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PURCHASE4003", "이미 결제된 글입니다."),
+    PURCHASE_SELF_CONTENT(HttpStatus.BAD_REQUEST, "PURCHASE4004", "본인의 글은 결제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/otakumap/global/apiPayload/exception/handler/TransactionHandler.java
+++ b/src/main/java/com/otakumap/global/apiPayload/exception/handler/TransactionHandler.java
@@ -1,0 +1,10 @@
+package com.otakumap.global.apiPayload.exception.handler;
+
+import com.otakumap.global.apiPayload.code.BaseErrorCode;
+import com.otakumap.global.apiPayload.exception.GeneralException;
+
+public class TransactionHandler extends GeneralException {
+    public TransactionHandler(BaseErrorCode code) {
+        super(code);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #170 

## 📝 작업 내용
- eventReview / placeReview의 point가 0 이상인 글을 구매하는 API를 구현하였습니다.
- 리뷰 상세 조회 시 price도 리턴하도록 수정하였습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 테스트
1. api 실행 전 userId 1, 2의 포인트 상태
<img width="817" alt="Screenshot 2025-02-19 at 05 56 35" src="https://github.com/user-attachments/assets/83d4c2e7-277b-4cd0-bd05-dadf78c48284" />
2. api 실행 
<img width="699" alt="Screenshot 2025-02-19 at 05 53 54" src="https://github.com/user-attachments/assets/f0ead2ab-f999-4a5a-9dff-30a5dcd0e02c" />
3. 트랜잭션 테이블에 데이터 등록
<img width="829" alt="Screenshot 2025-02-19 at 05 56 54" src="https://github.com/user-attachments/assets/47a9252b-c98c-4c87-8ec8-28fa9c7bcff6" />
4. userId 1, 2의 포인트 상태 변경
<img width="963" alt="Screenshot 2025-02-19 at 05 57 07" src="https://github.com/user-attachments/assets/a2e0001d-3184-4143-bc97-c67c39977804" />

<br />
이벤트 상세 조회 api price return
<img width="1386" alt="Screenshot 2025-02-19 at 06 10 38" src="https://github.com/user-attachments/assets/4deda493-389f-42fe-8db7-4fe92eddba6f" />

<br />
- 예외 처리
존재하지 않는 리뷰 ID인 경우
<img width="698" alt="Screenshot 2025-02-19 at 05 52 53" src="https://github.com/user-attachments/assets/b1e46493-1e6f-4ba3-b9d2-7a81900a9c9d" />

무료(price=0)의 글인 경우
<img width="697" alt="Screenshot 2025-02-19 at 05 52 45" src="https://github.com/user-attachments/assets/77494b24-9ccb-4b07-9831-46c0f02a142a" />

본인이 작성한 글일 경우
<img width="703" alt="Screenshot 2025-02-19 at 05 52 38" src="https://github.com/user-attachments/assets/fb10a2a0-d8e4-40b4-975c-3a37e060c13c" />

이미 결제된 글일 경우
<img width="1402" alt="Screenshot 2025-02-19 at 05 38 19" src="https://github.com/user-attachments/assets/03e2f8f7-01d3-45c4-a3f1-e977fb7a2549" />
