### PR TITLE
Feat: 유저 개인정보 조회 API 호출 시 후기 후원금 내역 조회 가능하게 변경

### DIFF
--- a/src/main/java/com/otakumap/domain/reviews/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/otakumap/domain/reviews/repository/ReviewRepositoryImpl.java
@@ -22,6 +22,7 @@ import com.otakumap.domain.transaction.entity.Transaction;
 import com.otakumap.domain.transaction.enums.TransactionType;
 import com.otakumap.domain.transaction.repository.TransactionRepository;
 import com.otakumap.domain.user.entity.User;
+import com.otakumap.domain.user.repository.UserRepository;
 import com.otakumap.global.apiPayload.code.status.ErrorStatus;
 import com.otakumap.global.apiPayload.exception.handler.ReviewHandler;
 import com.otakumap.global.apiPayload.exception.handler.SearchHandler;
@@ -52,6 +53,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     private final PointRepository pointRepository;
     private final PlaceReviewRepository placeReviewRepository;
     private final TransactionRepository transactionRepository;
+    private final UserRepository userRepository;
 
     @Override
     public Page<ReviewResponseDTO.SearchedReviewPreViewDTO> getReviewsByKeyword(String keyword, int page, int size, String sort) {
@@ -223,6 +225,9 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             transactionRepository.save(new Transaction(buyerPoint, TransactionType.USAGE, priceInt, null, (PlaceReview) review));
             transactionRepository.save(new Transaction(sellerPoint, TransactionType.EARNING, priceInt, null, (PlaceReview) review));
         }
+        // 판매자 후원금 내역에 판매 금액만큼 추가하여 저장
+        seller.addEarnings(priceInt);
+        userRepository.save(seller);
         return ReviewResponseDTO.PurchaseReviewDTO.builder()
                 .remainingPoints(remainingPoints)
                 .build();

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -101,4 +101,8 @@ public class User extends BaseEntity {
     public void updateEmail(String email) {
         this.email = email;
     }
+
+    public void addEarnings(int price) {
+        this.donation += price;
+    }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #170 

## 📝 작업 내용
- 후기 구매 진행 시 판매자의 후원금 내역에 판매된 값만큼 추가하여 유저 개인정보 조회 API 호출 시 후원금 내역이 제대로 나오도록 수정

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

구매 진행을 통해 user에게 500만큼의 포인트가 들어감
<img width="813" alt="Screenshot 2025-02-19 at 20 39 55" src="https://github.com/user-attachments/assets/4e2fb5e0-f777-4e93-b83c-eceb2965686b" />
user 데이터가 의도한대로 변경
<img width="380" alt="Screenshot 2025-02-19 at 20 41 02" src="https://github.com/user-attachments/assets/42f91d5b-c30e-44c3-b843-693de606e906" />
유저 개인정보 조회 API 호출 시 데이터가 제대로 나옴
<img width="432" alt="Screenshot 2025-02-19 at 20 41 43" src="https://github.com/user-attachments/assets/d2cdb71e-75a2-4e64-9204-57e068644666" />
