### PR TITLE
Fix: 알림 설정 변경 API가 정상 작동하지 않는 문제 수정

### DIFF
--- a/src/main/java/com/otakumap/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/otakumap/domain/user/dto/UserRequestDTO.java
@@ -31,7 +31,7 @@ public class UserRequestDTO {
         private Integer notificationType;
 
         @NotNull
-        private boolean isEnabled;
+        private Boolean isEnabled;
     }
 
     @Getter

--- a/src/main/java/com/otakumap/domain/user/entity/User.java
+++ b/src/main/java/com/otakumap/domain/user/entity/User.java
@@ -54,11 +54,11 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Integer donation;
 
-    @ColumnDefault("true")
+    @ColumnDefault("1")
     @Column(nullable = false)
     private Boolean isCommunityActivityNotified;
 
-    @ColumnDefault("true")
+    @ColumnDefault("1")
     @Column(nullable = false)
     private Boolean isEventBenefitsNotified;
 

--- a/src/main/java/com/otakumap/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/otakumap/domain/user/service/UserCommandServiceImpl.java
@@ -58,7 +58,7 @@ public class UserCommandServiceImpl implements UserCommandService {
         if (request.getNotificationType() != 1 && request.getNotificationType() != 2) {
             throw new UserHandler(ErrorStatus.INVALID_NOTIFICATION_TYPE);
         }
-        user.setNotification(request.getNotificationType(), request.isEnabled());
+        user.setNotification(request.getNotificationType(), request.getIsEnabled());
         userRepository.save(user);
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #225 

## 📝 작업 내용
- User 엔티티의 알림 설정 필드 타입을 primitive boolean에서 wrapper Boolean으로 변경
- DTO의 isEnabled 필드도 Boolean으로 변경하여 Hibernate 변경 감지 개선

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
알림 설정 변경 API 실행 시 200으로 응답이 오지만 DB에는 변경사항이 반영이 안되어 수정하였습니다.
찾아보니 primitive 타입(boolean)의 경우 값 자체만 변경되므로 때때로 변경 감지가 제대로 동작하지 않을 수 있고, wrapper 타입(Boolean)의 경우 새로운 객체가 할당되므로 변경 감지가 더 확실하게 동작한다고 해서 기존에 boolean이었던 알림 필드를 Boolean으로 변경하였습니다.

DB에 변경사항이 잘 반영되는 것까지 확인 완료했습니다!
![image](https://github.com/user-attachments/assets/08b161d5-53fb-4481-acb9-17ddf709d8a1)